### PR TITLE
JSHintValidationError: ignore nil errors

### DIFF
--- a/lib/zendesk_apps_support/validations/validation_error.rb
+++ b/lib/zendesk_apps_support/validations/validation_error.rb
@@ -17,7 +17,7 @@ module ZendeskAppsSupport
       attr_reader :filename, :jshint_errors
 
       def initialize(filename, jshint_errors)
-        errors = jshint_errors.map { |err| "\n  L#{err['line']}: #{err['reason']}" }.join('')
+        errors = jshint_errors.compact.map { |err| "\n  L#{err['line']}: #{err['reason']}" }.join('')
         @filename = filename, @jshint_errors = jshint_errors
         super(:jshint_errors, {
           :file => filename,

--- a/spec/validations/jshint_error_spec.rb
+++ b/spec/validations/jshint_error_spec.rb
@@ -1,0 +1,17 @@
+require 'zendesk_apps_support'
+
+describe ZendeskAppsSupport::Validations::JSHintValidationError do
+
+  let(:filename) { 'foo.js' }
+
+  context 'with nil errors' do
+
+    let(:errors) { [ nil, { 'line' => 12, 'reason' => 'eval is evil' }, nil ] }
+    let(:error) { ZendeskAppsSupport::Validations::JSHintValidationError.new(filename, errors) }
+
+    it 'ignores nil errors' do
+      error.to_s.should =~ /eval is evil/
+    end
+  end
+
+end


### PR DESCRIPTION
JSHint sometimes returns nil errors. The JSHintValidationError must ignore them so as not to blow up when building the error message.

cf https://github.com/zendesk/zendesk_app_market/commit/c45c7dee3c5af9be7cd5076f477414ab447eefa9
