### PR TITLE
Warn if parameter's type is not available

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,9 @@ en:
               other: ! '%{invalid_params} are set to hidden and cannot be required.'
             parameters_not_an_array: App parameters must be an array.
             duplicate_parameters: ! 'Duplicate app parameters defined: %{duplicate_parameters}'
+            invalid_type_parameter:
+              one: '%{invalid_types} is an invalid parameter type.'
+              two: '%{invalid_types} are invalid parameter types.'
             translation:
               invalid_locale: ! '%{file} is not a valid locale. Only two- and three-letter
                 ISO 639 language codes are allowed.'

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -97,7 +97,7 @@ module ZendeskAppsSupport
           end
 
           if invalid_types.any?
-            ValidationError.new(:invalid_type_parameter, :invalid_parameter_type => invalid_types.join(', '), :count => invalid_types.length)
+            ValidationError.new(:invalid_type_parameter, :invalid_types => invalid_types.join(', '), :count => invalid_types.length)
           end
         end
 

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -155,7 +155,9 @@ describe ZendeskAppsSupport::Validations::Manifest do
         ]
       }
       errors = ZendeskAppsSupport::Validations::Manifest.call(create_package(default_required_params.merge(parameter_hash)))
+
       expect(errors.count).to eq 1
+      expect(errors.first.to_s).to eq "integer is an invalid parameter type."
     end
 
     it 'has an no error when the parameter type is valid' do


### PR DESCRIPTION
Hi guys, 

I made this pull request because the error message displayed when the type of the parameter is wrong is not clear enough (currently, `Validation failed: Parameters is invalid`).

Any feedbacks?

Thanks,

Pierre
