### PR TITLE
Remove json dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,6 @@ PATH
       erubis
       i18n
       jshintrb (= 0.1.6)
-      json (~> 1.7.7)
       multi_json
       sass
 
@@ -15,14 +14,12 @@ GEM
     bump (0.4.2)
     diff-lcs (1.1.3)
     erubis (2.7.0)
-    execjs (1.4.0)
-      multi_json (~> 1.0)
-    i18n (0.6.4)
+    execjs (2.0.1)
+    i18n (0.6.5)
     jshintrb (0.1.6)
       execjs
       multi_json (>= 1.3)
       rake
-    json (1.7.7)
     multi_json (1.7.9)
     rake (10.1.0)
     rspec (2.12.0)

--- a/lib/zendesk_apps_support/assets/src.js.erb
+++ b/lib/zendesk_apps_support/assets/src.js.erb
@@ -3,22 +3,22 @@
 
         var source = <%= source %>;
 
-        ZendeskApps[<%= name.to_json %>] = ZendeskApps.defineApp(source)
-                .reopenClass({ location: <%= location.to_json %> })
+        ZendeskApps[<%= name %>] = ZendeskApps.defineApp(source)
+                .reopenClass({ location: <%= location %> })
                 .reopen({
-                    assetUrlPrefix: <%= asset_url_prefix.to_json %>,
-                    appClassName: <%= app_class_name.to_json %>,
+                    assetUrlPrefix: <%= asset_url_prefix %>,
+                    appClassName: <%= app_class_name %>,
                     author: {
-                        name: <%= author[:name].to_json %>,
-                        email: <%= author[:email].to_json %>
+                        name: <%= author_name %>,
+                        email: <%= author_email %>
                     },
-                    translations: <%= translations.to_json %>,
-                    templates: <%= templates.to_json %>,
-                    frameworkVersion: <%= framework_version.to_json %>
+                    translations: <%= translations %>,
+                    templates: <%= templates %>,
+                    frameworkVersion: <%= framework_version %>
                 });
 
     }
 
-    ZendeskApps[<%= name.to_json %>].install({"id": <%= app_id %>, "app_id": <%= app_id %>, "settings": <%= settings.to_json %>});
+    ZendeskApps[<%= name %>].install({"id": <%= app_id %>, "app_id": <%= app_id %>, "settings": <%= settings %>});
 
 }());

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -1,6 +1,6 @@
 require 'pathname'
 require 'erubis'
-require 'json'
+require 'multi_json'
 
 module ZendeskAppsSupport
   class Package
@@ -37,7 +37,7 @@ module ZendeskAppsSupport
     end
 
     def manifest_json
-      JSON.parse(File.read(File.join(root, "manifest.json")), :symbolize_names => true)
+      MultiJson.decode(File.read(File.join(root, "manifest.json")), :symbolize_names => true)
     end
 
     def readified_js(app_name, app_id, asset_url_prefix, settings={})
@@ -47,23 +47,24 @@ module ZendeskAppsSupport
       location = manifest[:location]
       app_class_name = "app-#{app_id}"
       author = manifest[:author]
-      translations = JSON.parse(File.read(File.join(root, "translations/en.json")))
+      translations = MultiJson.decode(File.read(File.join(root, "translations/en.json")))
       framework_version = manifest[:frameworkVersion]
       templates = manifest[:noTemplate] ? {} : compiled_templates(app_id, asset_url_prefix)
 
       settings["title"] = name
 
       SRC_TEMPLATE.result(
-          :name => name,
+          :name => as_json(name),
           :source => source,
-          :location => location,
-          :asset_url_prefix => asset_url_prefix,
-          :app_class_name => app_class_name,
-          :author => author,
-          :translations => translations,
-          :framework_version => framework_version,
-          :templates => templates,
-          :settings => settings,
+          :location => as_json(location),
+          :asset_url_prefix => as_json(asset_url_prefix),
+          :app_class_name => as_json(app_class_name),
+          :author_name => as_json(author[:name]),
+          :author_email => as_json(author[:email]),
+          :translations => as_json(translations),
+          :framework_version => as_json(framework_version),
+          :templates => as_json(templates),
+          :settings => as_json(settings),
           :app_id => app_id
       )
     end
@@ -104,5 +105,10 @@ module ZendeskAppsSupport
       end
       files
     end
+
+    def as_json(object)
+      MultiJson.encode object
+    end
+
   end
 end

--- a/spec/app_version_spec.rb
+++ b/spec/app_version_spec.rb
@@ -18,7 +18,7 @@ describe ZendeskAppsSupport::AppVersion do
     it { should_not == ZendeskAppsSupport::AppVersion.new('0.2') }
 
     its(:to_s) { should == ZendeskAppsSupport::AppVersion::CURRENT }
-    its(:to_json) { should == ZendeskAppsSupport::AppVersion::CURRENT.to_json }
+    its(:to_json) { should == MultiJson.encode(ZendeskAppsSupport::AppVersion::CURRENT) }
   end
 
   describe 'the deprecated version' do
@@ -37,7 +37,7 @@ describe ZendeskAppsSupport::AppVersion do
     it { should_not == ZendeskAppsSupport::AppVersion.new('0.2') }
 
     its(:to_s) { should == ZendeskAppsSupport::AppVersion::DEPRECATED }
-    its(:to_json) { should == ZendeskAppsSupport::AppVersion::DEPRECATED.to_json }
+    its(:to_json) { should == MultiJson.encode(ZendeskAppsSupport::AppVersion::DEPRECATED) }
   end
 
   describe 'a really old version' do
@@ -56,6 +56,6 @@ describe ZendeskAppsSupport::AppVersion do
     it { should_not == ZendeskAppsSupport::AppVersion.new('0.2') }
 
     its(:to_s) { should == '0.1' }
-    its(:to_json) { should == '0.1'.to_json }
+    its(:to_json) { should == MultiJson.encode('0.1') }
   end
 end

--- a/spec/validations/validation_serialization_spec.rb
+++ b/spec/validations/validation_serialization_spec.rb
@@ -14,14 +14,14 @@ describe ZendeskAppsSupport::Validations::ValidationError do
     let(:key)   { 'foo.bar' }
     let(:data)  { { 'baz' => 'quux' } }
     let(:error) { ValidationError.new(key, data) }
-    subject     { error.to_json }
+    subject     { MultiJson.encode(error) }
 
     it do
-      should == {
+      should == MultiJson.encode({
                   'class' => error.class.to_s,
                   'key'   => error.key,
                   'data'  => error.data
-                }.to_json
+                })
     end
   end
 

--- a/zendesk_apps_support.gemspec
+++ b/zendesk_apps_support.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'i18n'
   s.add_runtime_dependency 'multi_json'
   s.add_runtime_dependency 'sass'
-  s.add_runtime_dependency 'json', '~> 1.7.7'
   s.add_runtime_dependency 'erubis'
   s.add_runtime_dependency 'jshintrb',    '0.1.6'
 


### PR DESCRIPTION
@danielbreves @seancaffery @svizzari

This project already had MultiJson. There was no reason to tie it specifically to the json gem, which requires C extensions. MultiJson is more portable and will use whichever JSON codec is available.

The one downside is having to replace calls to `some_variable.to_json` with `MultiJson.encode(some_varible)`.
