### PR TITLE
[APPS-1274][BUG] Prevent parameter names from being "name"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,6 +27,7 @@ en:
             invalid_location:
               one: '%{invalid_locations} is an invalid location.'
               other: '%{invalid_locations} are invalid locations.'
+            name_as_parameter_name: Can't call a parameter 'name'
             invalid_hidden_parameter:
               one: '%{invalid_params} is set to hidden and cannot be required.'
               other: '%{invalid_params} are set to hidden and cannot be required.'

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -64,6 +64,10 @@ parts:
       title: "App builder job: invalid locations"
       value: "%{invalid_locations} are invalid locations."
   - translation:
+      key: "txt.apps.admin.error.app_build.name_as_parameter_name"
+      title: "App builder job: error message when developer names a parameter 'name'"
+      value: "Can't call a parameter 'name'"
+  - translation:
       key: "txt.apps.admin.error.app_build.invalid_hidden_parameter.one"
       title: "App builder job: hidden parameters set to required"
       value: "%{invalid_params} is set to hidden and cannot be required."

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -26,6 +26,7 @@ module ZendeskAppsSupport
             errors << parameters_error(manifest)
             errors << invalid_hidden_parameter_error(manifest)
             errors << invalid_type_error(manifest)
+            errors << name_as_parameter_name_error(manifest)
             errors.compact!
           end
         rescue MultiJson::DecodeError => e
@@ -99,6 +100,14 @@ module ZendeskAppsSupport
 
           unless valid_to_serve.include?(target_version)
             return ValidationError.new(:invalid_version, :target_version => target_version, :available_versions => valid_to_serve.join(', '))
+          end
+        end
+
+        def name_as_parameter_name_error(manifest)
+          if manifest['parameters'].kind_of?(Array)
+            if manifest['parameters'].any? { |p| p['name'] == 'name' }
+              ValidationError.new(:name_as_parameter_name)
+            end
           end
         end
 

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -129,6 +129,18 @@ describe ZendeskAppsSupport::Validations::Manifest do
       errors.map(&:to_s).should == ['App parameters must be an array.']
     end
 
+    it 'has an error when there is a parameter called "name"' do
+      parameter_hash = {
+          'parameters' => [{
+              'name' => 'name',
+              'type' => 'text'
+          }]
+      }
+
+      errors = ZendeskAppsSupport::Validations::Manifest.call(create_package(parameter_hash))
+      errors.map(&:to_s).should == ["Can't call a parameter 'name'"]
+    end
+
     it "doesn't have an error with an array of app parameters" do
       parameter_hash = {
           'parameters' => [{


### PR DESCRIPTION
**NOTE:** This is v2 of this PR. I bumped the ruby version, and redid this, so it would be less confusing.

We added a validation to stop people from calling their parameters "name":

zendesk/zendesk_app_market#619
https://zendesk.atlassian.net/browse/APPS-1274

/cc @zendesk/quokka
