### PR TITLE
Remove call to File's private respond_to_missing? method

### DIFF
--- a/lib/zendesk_apps_support/app_file.rb
+++ b/lib/zendesk_apps_support/app_file.rb
@@ -36,7 +36,7 @@ module ZendeskAppsSupport
 
     # If Ruby 1.9
     def respond_to_missing?(sym, include_private = false)
-      @file.respond_to_missing?(sym, include_private) || super
+      @file.send(:respond_to_missing?, sym, include_private) || super
     end
 
   end


### PR DESCRIPTION
`respond_to_missing?` is private, and calling it like @file.respond_to_missing? will always raise an exception. So I've replaced it with `.send` here.

@tmcinerney @grosser
