### PR TITLE
Check for requirements.json without trying to read it

### DIFF
--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -103,7 +103,7 @@ module ZendeskAppsSupport
     end
 
     def has_requirements?
-      !requirements_json.nil?
+      File.exist?(File.join(root, "requirements.json"))
     end
 
     def is_requirements_only?


### PR DESCRIPTION
`requirements_json` was throwing an exception when the file wasn't there.
