### PR TITLE
Refactor name and location of app requirements types

### DIFF
--- a/lib/zendesk_apps_support.rb
+++ b/lib/zendesk_apps_support.rb
@@ -7,6 +7,7 @@ module ZendeskAppsSupport
   autoload :BuildTranslation,       'zendesk_apps_support/build_translation'
   autoload :I18n,                   'zendesk_apps_support/i18n'
   autoload :Package,                'zendesk_apps_support/package'
+  autoload :AppRequirement,         'zendesk_apps_support/app_requirement'
   autoload :AppVersion,             'zendesk_apps_support/app_version'
   autoload :StylesheetCompiler,     'zendesk_apps_support/stylesheet_compiler'
 

--- a/lib/zendesk_apps_support/app_requirement.rb
+++ b/lib/zendesk_apps_support/app_requirement.rb
@@ -1,0 +1,5 @@
+module ZendeskAppsSupport
+  class AppRequirement
+    TYPES = %w(automations macros targets ticket_fields triggers user_fields).freeze
+  end
+end

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -6,8 +6,6 @@ module ZendeskAppsSupport
   module Validations
     module Requirements
 
-      REQUIREMENTS_TYPES = %w(automations macros targets ticket_fields triggers user_fields).freeze
-
       class <<self
         def call(package)
           requirements_file = package.files.find { |f| f.relative_path == 'requirements.json' }
@@ -32,7 +30,7 @@ module ZendeskAppsSupport
         private
 
         def invalid_requirements_types(requirements)
-          invalid_types = requirements.keys - REQUIREMENTS_TYPES
+          invalid_types = requirements.keys - ZendeskAppsSupport::AppRequirement::TYPES
 
           unless invalid_types.empty?
             ValidationError.new(:invalid_requirements_types, :invalid_types => invalid_types.join(', '), :count => invalid_types.length)


### PR DESCRIPTION
Create a new class to hold everything related to apps requirements, rename the CONST to remove redundant portion.

/cc @zendesk/quokka
