### PR TITLE
Remove classic package from apps_support. This means that apps_support s...

### DIFF
--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -5,7 +5,6 @@ title: "Apps Support"
 packages:
   - default
   - apps_support
-  - classic
 
 parts:
   - translation:


### PR DESCRIPTION
...trings won't be avaiable for classic

@zendesk/quokka @jwswj @pdeuter just like app market
