### PR TITLE
[APPS-1544] Fire ready event from readified_js

### DIFF
--- a/lib/zendesk_apps_support/assets/src.js.erb
+++ b/lib/zendesk_apps_support/assets/src.js.erb
@@ -22,3 +22,5 @@
     ZendeskApps[<%= name.to_json %>].install({"id": <%= app_id %>, "app_id": <%= app_id %>, "settings": <%= settings.to_json %>});
 
 }());
+
+ZendeskApps.trigger && ZendeskApps.trigger('ready');

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -83,6 +83,8 @@ describe ZendeskAppsSupport::Package do
     ZendeskApps["ABC"].install({"id": 0, "app_id": 0, "settings": {\"title\":\"ABC\"}});
 
 }());
+
+ZendeskApps.trigger && ZendeskApps.trigger('ready');
 HERE
       js.should == expected
     end


### PR DESCRIPTION
:koala: :+1:

/cc @zendesk/quokka
### Description

To implement LB we added events to framework.js and installed.js. This PR fires the same event that installed.js would have if it was loaded from the server when `zat serve` is being used.
### References
- Jira link: https://zendesk.atlassian.net/browse/APPS-1544
### Risks
- If readified_js is ever called twice, it will fire the ready event twice which will likely break Lotus
