### PR TITLE
Relax jshint when using [] notation unnecessarily

### DIFF
--- a/lib/zendesk_apps_support/validations/source.rb
+++ b/lib/zendesk_apps_support/validations/source.rb
@@ -12,6 +12,7 @@ module ZendeskAppsSupport
         # relaxing options:
         :eqnull => true,
         :laxcomma => true,
+        :sub => true,
 
         # predefined globals:
         :predef => %w(_ console services helpers alert window document self

--- a/spec/validations/source_spec.rb
+++ b/spec/validations/source_spec.rb
@@ -38,6 +38,14 @@ describe ZendeskAppsSupport::Validations::Source do
     errors.first.to_s.should eql "JSHint error in app.js: \n  L1: Missing semicolon."
   end
 
+  it 'should not have a jslint error when using [] notation unnecessarily' do
+    source = mock('AppFile', :relative_path => 'app.js', :read => "var a = {}; a['b'] = 0;")
+    package = mock('Package', :root => '.', :files => [source], :lib_files => [], :requirements_only => false)
+    errors = ZendeskAppsSupport::Validations::Source.call(package)
+
+    errors.should be_nil
+  end
+
   it 'should have a jslint error when missing semicolon in lib js file' do
     package = ZendeskAppsSupport::Package.new('spec/invalid_app')
     errors  = ZendeskAppsSupport::Validations::Source.call(package)


### PR DESCRIPTION
:koala:

Relax jshint when using [] notation unnecessarily by setting the [sub](http://www.jshint.com/docs/options/#sub) option.

Not sure what's going on with `nil`s, empty arrays and the flattens from the source validation, but that's another issue.

/cc @zendesk/quokka
### Risks
- We will no longer warn developers they are doing something they don't have to do
