### PR TITLE
Sort lib_files to ensure consistent ordering in tests

### DIFF
--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -3,6 +3,11 @@ require 'spec_helper'
 describe ZendeskAppsSupport::Package do
   before do
     @package = ZendeskAppsSupport::Package.new('spec/app')
+
+    lib_files_original_method = @package.method(:lib_files)
+    @package.stub(:lib_files) do |*args, &block|
+      lib_files_original_method.call(*args, &block).sort_by { |f| f.relative_path }
+    end
   end
 
   describe 'files' do


### PR DESCRIPTION
:koala:

Sort lib_files to ensure consistent ordering in tests.

Example failure: https://travis-ci.org/zendesk/zendesk_apps_support/builds/25572233

/cc @zendesk/quokka
### Risks
- None
