### PR TITLE
[APPS-2169] Allow routing based on app ID

### DIFF
--- a/lib/zendesk_apps_support/assets/src.js.erb
+++ b/lib/zendesk_apps_support/assets/src.js.erb
@@ -14,11 +14,7 @@
     var source = <%= source %>;
 
     var app = ZendeskApps.defineApp(source)
-      .reopenClass({
-        location: <%= location.to_json %>,
-        noTemplate: <%= no_template.to_json %>
-        singleInstall: <%= single_install.to_json %>
-      })
+      .reopenClass(<%= app_settings.to_json %>)
       .reopen({
         assetUrlPrefix: <%= asset_url_prefix.to_json %>,
         appClassName: <%= app_class_name.to_json %>,

--- a/lib/zendesk_apps_support/assets/src.js.erb
+++ b/lib/zendesk_apps_support/assets/src.js.erb
@@ -14,7 +14,11 @@
     var source = <%= source %>;
 
     var app = ZendeskApps.defineApp(source)
-      .reopenClass({ location: <%= location.to_json %> })
+      .reopenClass({
+        location: <%= location.to_json %>,
+        noTemplate: <%= no_template.to_json %>
+        singleInstall: <%= single_install.to_json %>
+      })
       .reopen({
         assetUrlPrefix: <%= asset_url_prefix.to_json %>,
         appClassName: <%= app_class_name.to_json %>,

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -111,7 +111,7 @@ module ZendeskAppsSupport
         :location => location,
         :noTemplate => no_template,
         :singleInstall => single_install
-      }.keep_if { |k,v| !v.nil? }
+      }.select { |k,v| !v.nil? }
 
       SRC_TEMPLATE.result(
           :name => name,

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -101,14 +101,22 @@ module ZendeskAppsSupport
       app_class_name = "app-#{app_id}"
       author = manifest[:author]
       framework_version = manifest[:frameworkVersion]
-      templates = manifest[:noTemplate] ? {} : compiled_templates(app_id, asset_url_prefix)
+      single_install = manifest[:singleInstall] || false
+      no_template = manifest[:noTemplate]
+      templates = no_template ? {} : compiled_templates(app_id, asset_url_prefix)
 
       settings["title"] = name
+
+      app_settings = {
+        :location => location,
+        :noTemplate => no_template,
+        :singleInstall => single_install
+      }.keep_if { |k,v| !v.nil? }
 
       SRC_TEMPLATE.result(
           :name => name,
           :source => source,
-          :location => location,
+          :app_settings => app_settings,
           :asset_url_prefix => asset_url_prefix,
           :app_class_name => app_class_name,
           :author => author,

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -108,7 +108,7 @@ module.exports = b;
 ;
 
     var app = ZendeskApps.defineApp(source)
-      .reopenClass({ location: "ticket_sidebar" })
+      .reopenClass({"location":"ticket_sidebar","singleInstall":false})
       .reopen({
         assetUrlPrefix: "http://localhost:4567/",
         appClassName: "app-0",


### PR DESCRIPTION
:koala:

This PR adds `noTemplate` and `singleInstall` app-level settings for `zat serve`. Ultimately, I'd like ZAM to serve `installed.js` with the `singleInstall` setting serialized to support identification of whether an app is single install for routing purposes.

/cc @zendesk/quokka

### References
 - Jira link: https://zendesk.atlassian.net/browse/APPS-2169

### Risks
 - None