### PR TITLE
load the requested translations, not just english

### DIFF
--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -84,12 +84,13 @@ module ZendeskAppsSupport
       read_json('requirements.json')
     end
 
-    def translations
-      read_json('translations/en.json', false)
+    def translations(locale)
+      locale ||= "en"
+      read_json("translations/#{locale}.json", false)
     end
 
-    def app_translations
-      remove_zendesk_keys(translations)
+    def app_translations(locale)
+      remove_zendesk_keys(translations(locale))
     end
 
     def readified_js(app_name, app_id, asset_url_prefix, settings = {})
@@ -112,6 +113,7 @@ module ZendeskAppsSupport
         singleInstall: single_install
       }.select { |_k, v| !v.nil? }
 
+
       SRC_TEMPLATE.result(
           name: name,
           source: source,
@@ -119,7 +121,7 @@ module ZendeskAppsSupport
           asset_url_prefix: asset_url_prefix,
           app_class_name: app_class_name,
           author: author,
-          translations: app_translations,
+          translations: app_translations(settings[:locale]),
           framework_version: framework_version,
           templates: templates,
           settings: settings,

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -85,8 +85,9 @@ module ZendeskAppsSupport
     end
 
     def translations(locale)
-      locale ||= "en"
-      read_json("translations/#{locale}.json", false)
+      file_path = "translations/#{locale}.json"
+      file_path = "translations/en.json" unless file_exists?(file_path)
+      read_json(file_path, false)
     end
 
     def app_translations(locale)
@@ -112,7 +113,6 @@ module ZendeskAppsSupport
         noTemplate: no_template,
         singleInstall: single_install
       }.select { |_k, v| !v.nil? }
-
 
       SRC_TEMPLATE.result(
           name: name,

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -94,7 +94,7 @@ module ZendeskAppsSupport
       remove_zendesk_keys(translations(locale))
     end
 
-    def readified_js(app_name, app_id, asset_url_prefix, settings = {})
+    def readified_js(app_name, app_id, asset_url_prefix, settings = {}, locale = 'en')
       manifest = manifest_json
       source = app_js
       name = app_name || manifest[:name] || 'Local App'
@@ -121,7 +121,7 @@ module ZendeskAppsSupport
           asset_url_prefix: asset_url_prefix,
           app_class_name: app_class_name,
           author: author,
-          translations: app_translations(settings[:locale]),
+          translations: app_translations(locale),
           framework_version: framework_version,
           templates: templates,
           settings: settings,


### PR DESCRIPTION
Load the translations file requested, not always `en.json`. 

/cc @pdeuter @benhass @princemaple 

### References
 - Classic Change: https://github.com/zendesk/zendesk/pull/16964
 - ZAT Change: https://github.com/zendesk/zendesk_apps_tools/pull/86

### Risks
 - Low. Use a new param if their, otherwise continue using "en" as before. 