### PR TITLE
Bump current version of the framework to 1.0

### DIFF
--- a/lib/zendesk_apps_support/app_version.rb
+++ b/lib/zendesk_apps_support/app_version.rb
@@ -10,9 +10,9 @@ module ZendeskAppsSupport
   #                  newly created or updates apps MAY target it, but it
   #                  may change without notice
   class AppVersion
-    DEPRECATED = '0.4'.freeze
-    CURRENT    = '0.5'.freeze
-    FUTURE     = '1.0'.freeze
+    DEPRECATED = '0.5'.freeze
+    CURRENT    = '1.0'.freeze
+    FUTURE     = '2.0'.freeze
 
     TO_BE_SERVED     = [DEPRECATED, CURRENT, FUTURE].compact.freeze
     VALID_FOR_UPDATE = [CURRENT, FUTURE].compact.freeze


### PR DESCRIPTION
:koala:

1.0 has been the [official current version](https://developer.zendesk.com/apps/docs/agent/version_changelog#version-history) since September 30th 2014.

/cc @zendesk/quokka @maximeprades @chucknado 

### Risks
 - Developers will no longer be able to update apps running on 0.5