### PR TITLE
added version and app name for zas!

### DIFF
--- a/lib/zendesk_apps_support/assets/src.js.erb
+++ b/lib/zendesk_apps_support/assets/src.js.erb
@@ -32,7 +32,7 @@
     ZendeskApps[<%= name.to_json %>] = app;
   }
 
-  ZendeskApps[<%= name.to_json %>].install({"id": <%= app_id %>, "app_id": <%= app_id %>, "name": <%= name.to_json %>, "settings": <%= settings.to_json %>});
+  ZendeskApps[<%= name.to_json %>].install({"id": <%= app_id %>, "app_id": <%= app_id %>, "settings": <%= settings.to_json %>});
 }());
 
 ZendeskApps.trigger && ZendeskApps.trigger('ready');

--- a/lib/zendesk_apps_support/assets/src.js.erb
+++ b/lib/zendesk_apps_support/assets/src.js.erb
@@ -16,6 +16,8 @@
     var app = ZendeskApps.defineApp(source)
       .reopenClass(<%= app_settings.to_json %>)
       .reopen({
+        appName: <%= name.to_json %>,
+        appVersion: <%= version.to_json %>,
         assetUrlPrefix: <%= asset_url_prefix.to_json %>,
         appClassName: <%= app_class_name.to_json %>,
         author: {
@@ -30,7 +32,7 @@
     ZendeskApps[<%= name.to_json %>] = app;
   }
 
-  ZendeskApps[<%= name.to_json %>].install({"id": <%= app_id %>, "app_id": <%= app_id %>, "settings": <%= settings.to_json %>});
+  ZendeskApps[<%= name.to_json %>].install({"id": <%= app_id %>, "app_id": <%= app_id %>, "name": <%= name.to_json %>, "settings": <%= settings.to_json %>});
 }());
 
 ZendeskApps.trigger && ZendeskApps.trigger('ready');

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -99,6 +99,7 @@ module ZendeskAppsSupport
       source = app_js
       name = app_name || manifest[:name] || 'Local App'
       location = manifest[:location]
+      version = manifest[:version]
       app_class_name = "app-#{app_id}"
       author = manifest[:author]
       framework_version = manifest[:frameworkVersion]
@@ -116,6 +117,7 @@ module ZendeskAppsSupport
 
       SRC_TEMPLATE.result(
           name: name,
+          version: version,
           source: source,
           app_settings: app_settings,
           asset_url_prefix: asset_url_prefix,

--- a/spec/app/manifest.json
+++ b/spec/app/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "ABC",
+  "version": "1.0.0",
   "author": {
     "name": "John Smith",
     "email": "john@example.com"

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -112,6 +112,8 @@ module.exports = b;
     var app = ZendeskApps.defineApp(source)
       .reopenClass({"location":"ticket_sidebar","singleInstall":false})
       .reopen({
+        appName: "ABC",
+        appVersion: "1.0.0",
         assetUrlPrefix: "http://localhost:4567/",
         appClassName: "app-0",
         author: {


### PR DESCRIPTION
Added the same three properties to app.js to mimic zam correctly.

Installation name is the same as the app name. In ZAM these are different.

https://github.com/zendesk/zendesk_app_market/pull/1378

/cc @zendesk/quokka