### PR TITLE
Allow having .scss file too

### DIFF
--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -200,7 +200,8 @@ module ZendeskAppsSupport
 
     def app_css
       css_file = path_to('app.css')
-      File.exist?(css_file) ? File.read(css_file) : ''
+      scss_file = path_to('app.scss')
+      File.exist?(scss_file) ? File.read(scss_file) : ( File.exist?(css_file) ? File.read(css_file) : '' )
     end
 
     def locations

--- a/lib/zendesk_apps_support/validations/source.rb
+++ b/lib/zendesk_apps_support/validations/source.rb
@@ -32,7 +32,7 @@ module ZendeskAppsSupport
             return (package_has_code?(package) ? [ ValidationError.new(:no_code_for_ifo_notemplate) ] : [])
           end
 
-          #jshint_errors(files).flatten!
+          jshint_errors(files).flatten!
         end
 
         private

--- a/lib/zendesk_apps_support/validations/source.rb
+++ b/lib/zendesk_apps_support/validations/source.rb
@@ -32,7 +32,7 @@ module ZendeskAppsSupport
             return (package_has_code?(package) ? [ ValidationError.new(:no_code_for_ifo_notemplate) ] : [])
           end
 
-          jshint_errors(files).flatten!
+          #jshint_errors(files).flatten!
         end
 
         private


### PR DESCRIPTION
Editors don't understand the SASS syntax inside .css file, this patch allows to maintain a .scss file instead of the regular .css file supplied.
`zat package` support available under zendesk/zendesk_apps_tools#115 .