### PR TITLE
[APPS-2928] add channel_integrations requirement type

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
             invalid_requirements_types:
               one: 'requirements.json contains an invalid type: %{invalid_types}'
               other: 'requirements.json contains invalid types: %{invalid_types}'
+            multiple_channel_integrations: 'Specifying multiple channel integrations in requirements.json is not supported.'
             banner:
               invalid_format: Banner image must be a PNG file.
               invalid_size: Invalid banner image dimensions. Must be %{required_banner_width}x%{required_banner_height}px.

--- a/lib/zendesk_apps_support/app_requirement.rb
+++ b/lib/zendesk_apps_support/app_requirement.rb
@@ -1,5 +1,5 @@
 module ZendeskAppsSupport
   class AppRequirement
-    TYPES = %w(automations macros targets views ticket_fields triggers user_fields).freeze
+    TYPES = %w(automations channel_integrations macros targets views ticket_fields triggers user_fields).freeze
   end
 end

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -66,8 +66,8 @@ module ZendeskAppsSupport
               errors << ValidationError.new(:multiple_channel_integrations, count: channel_integrations.size)
             end
             channel_integrations.each do |identifier, fields|
-              unless fields.include? 'manifest'
-                errors << ValidationError.new(:missing_required_fields, field: 'manifest', identifier: identifier)
+              unless fields.include? 'manifest_url'
+                errors << ValidationError.new(:missing_required_fields, field: 'manifest_url', identifier: identifier)
               end
             end
           end

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -73,4 +73,23 @@ describe ZendeskAppsSupport::Validations::Requirements do
 
     expect(errors.first.key).to eq(:duplicate_requirements)
   end
+
+  it 'creates an error if there are multiple channel integrations' do
+    requirements = double('AppFile', relative_path: 'requirements.json', read:
+      '{ "channel_integrations": { "one": { "manifest": "manifest"}, "two": { "manifest": "manifest"} }}')
+    package = double('Package', files: [requirements])
+    errors = ZendeskAppsSupport::Validations::Requirements.call(package)
+
+    expect(errors.first.key).to eq(:multiple_channel_integrations)
+  end
+
+  it 'creates an error if a channel integration is missing a manifest' do
+    requirements = double('AppFile', relative_path: 'requirements.json',
+                                     read: '{ "channel_integrations": { "channel_one": {} }}')
+    package = double('Package', files: [requirements])
+    errors = ZendeskAppsSupport::Validations::Requirements.call(package)
+
+    expect(errors.first.key).to eq(:missing_required_fields)
+    expect(errors.first.data).to eq({ field: 'manifest', identifier: 'channel_one' })
+  end
 end

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -76,7 +76,7 @@ describe ZendeskAppsSupport::Validations::Requirements do
 
   it 'creates an error if there are multiple channel integrations' do
     requirements = double('AppFile', relative_path: 'requirements.json', read:
-      '{ "channel_integrations": { "one": { "manifest": "manifest"}, "two": { "manifest": "manifest"} }}')
+      '{ "channel_integrations": { "one": { "manifest_url": "manifest"}, "two": { "manifest_url": "manifest"} }}')
     package = double('Package', files: [requirements])
     errors = ZendeskAppsSupport::Validations::Requirements.call(package)
 
@@ -90,6 +90,6 @@ describe ZendeskAppsSupport::Validations::Requirements do
     errors = ZendeskAppsSupport::Validations::Requirements.call(package)
 
     expect(errors.first.key).to eq(:missing_required_fields)
-    expect(errors.first.data).to eq({ field: 'manifest', identifier: 'channel_one' })
+    expect(errors.first.data).to eq({ field: 'manifest_url', identifier: 'channel_one' })
   end
 end


### PR DESCRIPTION
:bear:

Add `channel_integrations` type to requirements.

Add validation rules for at most one channel_integration, and require each to have a `manifest` field.

/cc @zendesk/wombat @zendesk/vegemite 

### References
 - Jira link: https://zendesk.atlassian.net/browse/APPS-2928

### Risks
 - None