### PR TITLE
AF-346 handle when location key is not supplied at all, fix some rubocop warnings

### DIFF
--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -206,12 +206,15 @@ module ZendeskAppsSupport
 
     def locations
       locations = manifest_json['location']
-      if locations.is_a?(Hash)
+      case locations
+      when Hash
         locations
-      elsif locations.is_a?(Array)
+      when Array
         { 'zendesk' => Hash[locations.map { |location| [ location, LEGACY_URI_STUB ] }] }
-      else # String
+      when String
         { 'zendesk' => { locations => LEGACY_URI_STUB } }
+      else # NilClass
+        { 'zendesk' => {} }
       end
     end
 

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -398,22 +398,28 @@ describe ZendeskAppsSupport::Package do
     end
   end
 
-  describe "#locations" do
-    it "supports strings" do
+  describe '#locations' do
+    it 'supports strings' do
       location_object = @package.send(:locations)
-      expect(location_object).to eq({"zendesk"=>{"ticket_sidebar"=>"_legacy"}})
+      expect(location_object).to eq('zendesk' => { 'ticket_sidebar' => '_legacy' })
     end
 
-    it "supports arrays" do
-      @package.manifest_json['location'] = %w[🔔 🃏]
+    it 'supports arrays' do
+      @package.manifest_json['location'] = %w(🔔 🃏)
       location_object = @package.send(:locations)
-      expect(location_object).to eq({"zendesk"=>{"🃏"=>"_legacy", "🔔"=>"_legacy"}})
+      expect(location_object).to eq('zendesk' => { '🃏' => '_legacy', '🔔' => '_legacy' })
     end
 
-    it "supports objects" do
-      @package.manifest_json['location'] = { 'zopim' => {'chat_sidebar' => 'http://www.zopim.com'} }
+    it 'supports objects' do
+      @package.manifest_json['location'] = { 'zopim' => { 'chat_sidebar' => 'http://www.zopim.com' } }
       location_object = @package.send(:locations)
       expect(location_object).to be @package.manifest_json['location']
+    end
+
+    it 'works when not present' do
+      @package.manifest_json.delete('location')
+      location_object = @package.send(:locations)
+      expect(location_object).to eq('zendesk' => {})
     end
   end
 


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite @zendesk/wombat 

### Description

We have code elsewhere that assumes `locations['zendesk'].keys` always returns a valid array of locations. However if the locations key was missing, that code snippet returns `[nil]`.

### References
https://zendesk.atlassian.net/browse/AF-346

### Risks
* [low] errors creating / updating no-location apps (eg requirements only)