### PR TITLE
Refactor a method

### DIFF
--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -140,7 +140,7 @@ module ZendeskAppsSupport
         asset_url_prefix: asset_url_prefix,
         app_class_name: app_class_name,
         author: author,
-        translations: translations_for(locale),
+        translations: runtime_translations(translations_for(locale)),
         framework_version: framework_version,
         templates: templates,
         modules: commonjs_modules,
@@ -183,13 +183,10 @@ module ZendeskAppsSupport
       end
     end
 
-    def market_translations!(locale)
-      result = translations[locale].fetch('app', {})
-      result.delete('name')
-      result.delete('description')
-      result.delete('long_description')
-      result.delete('installation_instructions')
-      result
+    def translations_for(locale)
+      trans = translations
+      return trans[locale] if trans[locale]
+      trans[self.manifest_json['defaultLocale']]
     end
 
     def has_location?
@@ -226,6 +223,16 @@ module ZendeskAppsSupport
 
     private
 
+
+    def runtime_translations(translations)
+      result = translations.dup
+      result.delete('name')
+      result.delete('description')
+      result.delete('long_description')
+      result.delete('installation_instructions')
+      result
+    end
+
     def legacy_non_iframe_app?
       iframe_urls = locations.values.flat_map(&:values)
       iframe_urls.all? { |l| l == LEGACY_URI_STUB }
@@ -239,12 +246,6 @@ module ZendeskAppsSupport
         memo[File.basename(file, File.extname(file))] = str
         memo
       end
-    end
-
-    def translations_for(locale)
-      trans = translations
-      return trans[locale] if trans[locale]
-      trans[self.manifest_json['defaultLocale']]
     end
 
     def translations

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -172,20 +172,6 @@ describe ZendeskAppsSupport::Package do
     })
   end
 
-  describe 'market_translations! works as expected' do
-    it 'builds an app' do
-      expect(package.manifest_json['author']['name']).to eq('Ned Stark')
-      expect(package.send(:translations)).to eq({"en"=>{"app"=>{"description"=>"Quickly access bookmarked tickets. Syncs with the iPad app."}, "custom1"=>"The first custom thing"}})
-      expect(package.send(:market_translations!, 'en')).to eq({})
-      expect(package.send(:translations)).to eq({"en"=>{"app"=>{}, "custom1"=>"The first custom thing"}})
-    end
-
-    it 'builds an app with changed manifest' do
-      manifest['author']['name'] = 'Olaf'
-      expect(package.manifest_json['author']['name']).to eq('Olaf')
-    end
-  end
-
   describe 'Reading a manifest' do
     it 'fetches data from the manifest' do
       expect(package.manifest_json['location']).to eq('ticket_sidebar')
@@ -280,11 +266,11 @@ describe ZendeskAppsSupport::Package do
     end
   end
 
-  describe '#market_translations!' do
-    let(:translations) { { 'app' => { 'name' => 'Some App', 'description' => 'It does something.' } } }
+  describe '#runtime_translations' do
+    let(:translations) { { 'app' => { 'name' => 'Some App', 'description' => 'It does something.', 'everything_else': 'preserved' } } }
     let(:source) { build_app_source(additional_files: { "translations/en.json" => translations.to_json }) }
 
-    subject { package.market_translations!('en') }
+    subject { package.send :runtime_translations, package.translations_for('en')['app'] }
 
     it 'ignores "name"' do
       expect(subject['name']).to be nil
@@ -292,6 +278,11 @@ describe ZendeskAppsSupport::Package do
 
     it 'ignores "description"' do
       expect(subject['description']).to be nil
+    end
+
+    it 'preserves the rest' do
+      puts subject
+      expect(subject['everything_else']).to eq 'preserved'
     end
   end
 

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -267,7 +267,15 @@ describe ZendeskAppsSupport::Package do
   end
 
   describe '#runtime_translations' do
-    let(:translations) { { 'app' => { 'name' => 'Some App', 'description' => 'It does something.', 'everything_else': 'preserved' } } }
+    let(:translations) do
+      {
+        'app' => {
+          'name' => 'Some App',
+          'description' => 'It does something.',
+          'everything_else' => 'preserved'
+        }
+      }
+    end
     let(:source) { build_app_source(additional_files: { "translations/en.json" => translations.to_json }) }
 
     subject { package.send :runtime_translations, package.translations_for('en')['app'] }

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -278,19 +278,10 @@ describe ZendeskAppsSupport::Package do
     end
     let(:source) { build_app_source(additional_files: { "translations/en.json" => translations.to_json }) }
 
-    subject { package.send :runtime_translations, package.translations_for('en')['app'] }
+    subject { package.send :runtime_translations, package.translations_for('en').fetch('app') }
 
-    it 'ignores "name"' do
-      expect(subject['name']).to be nil
-    end
-
-    it 'ignores "description"' do
-      expect(subject['description']).to be nil
-    end
-
-    it 'preserves the rest' do
-      puts subject
-      expect(subject['everything_else']).to eq 'preserved'
+    it 'ignores "name" and "description", preserving other keys' do
+      expect(subject).to eq('everything_else' => 'preserved')
     end
   end
 


### PR DESCRIPTION
This is for us to be able to store the long_description and installation_instructions in the app's zipfile, rather than as a separate manual installation step.

- `market_translations!` is now renamed to `runtime_translations`, no longer mutates its input and is a private method since it is only useful as an input to `compile_js`.
- `translations_for` is now public so that it can be used instead of `market_translations!` when persisting translations into a database when apps are uploaded.

### Risks

- [ medium ] translations stop working for new uploads