### PR TITLE
remove a dependency, do not load SASS every time this gem is required

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,6 @@ PATH
       image_size
       jshintrb (~> 0.3.0)
       json
-      json-stream
       sass
 
 GEM
@@ -27,7 +26,6 @@ GEM
       multi_json (>= 1.3)
       rake
     json (2.0.2)
-    json-stream (0.2.1)
     multi_json (1.12.1)
     rake (11.2.2)
     rspec (3.4.0)

--- a/lib/zendesk_apps_support.rb
+++ b/lib/zendesk_apps_support.rb
@@ -1,5 +1,4 @@
 module ZendeskAppsSupport
-  require 'zendesk_apps_support/sass_functions'
   require 'zendesk_apps_support/engine'
 
   autoload :AppFile,                'zendesk_apps_support/app_file'

--- a/lib/zendesk_apps_support/app_version.rb
+++ b/lib/zendesk_apps_support/app_version.rb
@@ -1,5 +1,3 @@
-require 'json'
-
 module ZendeskAppsSupport
   # At any point in time, we support up to three versions:
   #  * deprecated -- we will still serve apps targeting the deprecated version,

--- a/lib/zendesk_apps_support/manifest/no_override_hash.rb
+++ b/lib/zendesk_apps_support/manifest/no_override_hash.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-require 'json'
-
 module ZendeskAppsSupport
   class Manifest
     class OverrideError < StandardError

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -155,7 +155,7 @@ module ZendeskAppsSupport
 
     def requirements_json
       return nil unless has_requirements?
-      @requirements ||= read_json('requirements.json')
+      @requirements ||= read_json('requirements.json', object_class: Manifest::NoOverrideHash)
     end
 
     def is_no_template

--- a/lib/zendesk_apps_support/stylesheet_compiler.rb
+++ b/lib/zendesk_apps_support/stylesheet_compiler.rb
@@ -1,4 +1,5 @@
 require 'sass'
+require 'zendesk_apps_support/sass_functions'
 
 module ZendeskAppsSupport
   class StylesheetCompiler

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -1,4 +1,3 @@
-require 'json'
 require 'uri'
 
 module ZendeskAppsSupport

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -1,6 +1,3 @@
-require 'json'
-require 'json/stream'
-
 module ZendeskAppsSupport
   module Validations
     module Requirements
@@ -8,17 +5,14 @@ module ZendeskAppsSupport
 
       class <<self
         def call(package)
-          requirements_file = package.files.find { |f| f.relative_path == 'requirements.json' }
+          return [ValidationError.new(:missing_requirements)] unless package.has_file? 'requirements.json'
 
-          return [ValidationError.new(:missing_requirements)] unless requirements_file
-
-          requirements_stream = requirements_file.read
-          duplicates = non_unique_type_keys(requirements_stream)
-          unless duplicates.empty?
-            return [ValidationError.new(:duplicate_requirements, duplicate_keys: duplicates.join(', '), count: duplicates.length)]
+          begin
+            requirements = package.requirements_json
+          rescue ZendeskAppsSupport::Manifest::OverrideError => e
+            return [ValidationError.new(:duplicate_requirements, duplicate_keys: e.key, count: 1)]
           end
 
-          requirements = JSON.load(requirements_stream)
           [].tap do |errors|
             errors << invalid_requirements_types(requirements)
             errors << excessive_requirements(requirements)
@@ -85,19 +79,6 @@ module ZendeskAppsSupport
           unless invalid_types.empty?
             ValidationError.new(:invalid_requirements_types, invalid_types: invalid_types.join(', '), count: invalid_types.length)
           end
-        end
-
-        def non_unique_type_keys(requirements)
-          keys = []
-          duplicates = []
-          parser = JSON::Stream::Parser.new do
-            start_object { keys.push({}) }
-            end_object { keys.pop }
-            key { |k| duplicates.push(k) if keys.last.include? k; keys.last[k] = nil }
-          end
-          parser << requirements
-
-          duplicates
         end
       end
     end

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -1,95 +1,96 @@
 require 'spec_helper'
 require 'json'
+require 'tmpdir'
 
 describe ZendeskAppsSupport::Validations::Requirements do
-  it 'creates an error when the file is not valid JSON' do
-    requirements = double('AppFile', relative_path: 'requirements.json', read: '{')
-    package = double('Package', files: [requirements])
-    errors = ZendeskAppsSupport::Validations::Requirements.call(package)
+  before do
+    allow(package).to receive(:has_file?).with('requirements.json').and_return true
+    allow(package).to receive(:read_file).with('requirements.json') { requirements_string }
+  end
+  let(:dir) { Dir.mktmpdir }
+  let(:package) { ZendeskAppsSupport::Package.new(dir, false) }
+  let(:errors) { ZendeskAppsSupport::Validations::Requirements.call(package) }
 
-    expect(errors.first.key).to eq(:requirements_not_json)
+  context 'the file is not valid JSON' do
+    let(:requirements_string) { '{' }
+
+    it 'creates an error' do
+      expect(errors.first.key).to eq(:requirements_not_json)
+    end
   end
 
-  it 'creates no error when the file is valid JSON' do
-    requirements = double('AppFile', relative_path: 'requirements.json',
-                                     read: read_fixture_file('requirements.json'))
-    package = double('Package', files: [requirements])
-    errors = ZendeskAppsSupport::Validations::Requirements.call(package)
+  context 'the file is valid JSON' do
+    let(:requirements_string) { read_fixture_file('requirements.json') }
 
-    expect(errors).to be_empty
+    it 'creates no error' do
+      expect(errors).to be_empty
+    end
   end
 
-  it 'creates an error if there are more than 10 requirements' do
-    requirements_content = {}
-    max = ZendeskAppsSupport::Validations::Requirements::MAX_REQUIREMENTS
+  context 'there are more than 10 requirements' do
+    let(:requirements_string) do
+      requirements_content = {}
+      max = ZendeskAppsSupport::Validations::Requirements::MAX_REQUIREMENTS
 
-    ZendeskAppsSupport::AppRequirement::TYPES.each do |type|
-      requirements_content[type] = {}
-      (max - 1).times { |n| requirements_content[type]["#{type}#{n}"] = { 'title' => "#{type}#{n}" } }
+      ZendeskAppsSupport::AppRequirement::TYPES.each do |type|
+        requirements_content[type] = {}
+        (max - 1).times { |n| requirements_content[type]["#{type}#{n}"] = { 'title' => "#{type}#{n}" } }
+      end
+
+      JSON.generate(requirements_content)
     end
 
-    requirements = double('AppFile', relative_path: 'requirements.json',
-                                     read: JSON.generate(requirements_content))
-    package = double('Package', files: [requirements])
-    errors = ZendeskAppsSupport::Validations::Requirements.call(package)
-
-    expect(errors.first.key).to eq(:excessive_requirements)
+    it 'creates an error' do
+      expect(errors.first.key).to eq(:excessive_requirements)
+    end
   end
 
-  it 'creates an error for any requirement that is lacking required fields' do
-    requirements_content = { 'targets' => { 'abc' => {} } }
-    requirements = double('AppFile', relative_path: 'requirements.json',
-                                     read: JSON.generate(requirements_content))
-    package = double('Package', files: [requirements])
-    errors = ZendeskAppsSupport::Validations::Requirements.call(package)
+  context 'a requirement is lacking required fields' do
+    let(:requirements_string) { JSON.generate('targets' => { 'abc' => {} }) }
 
-    expect(errors.first.key).to eq(:missing_required_fields)
+    it 'creates an error for any requirement that is lacking required fields' do
+      expect(errors.first.key).to eq(:missing_required_fields)
+    end
   end
 
-  it 'creates an error for every requirement that is lacking required fields' do
-    requirements_content = { 'targets' => { 'abc' => {}, 'xyz' => {} } }
-    requirements = double('AppFile', relative_path: 'requirements.json',
-                                     read: JSON.generate(requirements_content))
-    package = double('Package', files: [requirements])
-    errors = ZendeskAppsSupport::Validations::Requirements.call(package)
+  context 'many requirements are lacking required fields' do
+    let(:requirements_string) { JSON.generate('targets' => { 'abc' => {}, 'xyz' => {} }) }
 
-    expect(errors.size).to eq(2)
+    it 'creates an error for each of them' do
+      expect(errors.size).to eq(2)
+    end
   end
 
-  it 'creates an error if there are invalid requirement types' do
-    requirements = double('AppFile', relative_path: 'requirements.json',
-                                     read: '{ "i_am_not_a_valid_type": {}}')
-    package = double('Package', files: [requirements])
-    errors = ZendeskAppsSupport::Validations::Requirements.call(package)
+  context 'there are invalid requirement types' do
+    let(:requirements_string) { '{ "i_am_not_a_valid_type": {}}' }
 
-    expect(errors.first.key).to eq(:invalid_requirements_types)
+    it 'creates an error' do
+      expect(errors.first.key).to eq(:invalid_requirements_types)
+    end
   end
 
-  it 'creates an error if there are duplicate requirements types' do
-    requirements = double('AppFile', relative_path: 'requirements.json',
-                                     read: '{ "a": { "b": 1, "b": 2 }}')
-    package = double('Package', files: [requirements])
-    errors = ZendeskAppsSupport::Validations::Requirements.call(package)
+  context 'there are duplicate requirements' do
+    let(:requirements_string) { '{ "a": { "b": 1, "b": 2 }}' }
 
-    expect(errors.first.key).to eq(:duplicate_requirements)
+    it 'creates an error' do
+      expect(errors.first.key).to eq(:duplicate_requirements)
+    end
   end
 
-  it 'creates an error if there are multiple channel integrations' do
-    requirements = double('AppFile', relative_path: 'requirements.json', read:
-      '{ "channel_integrations": { "one": { "manifest_url": "manifest"}, "two": { "manifest_url": "manifest"} }}')
-    package = double('Package', files: [requirements])
-    errors = ZendeskAppsSupport::Validations::Requirements.call(package)
+  context 'there are multiple channel integrations' do
+    let(:requirements_string) { '{ "channel_integrations": { "one": { "manifest_url": "manifest"}, "two": { "manifest_url": "manifest"} }}' }
 
-    expect(errors.first.key).to eq(:multiple_channel_integrations)
+    it 'creates an error' do
+      expect(errors.first.key).to eq(:multiple_channel_integrations)
+    end
   end
 
-  it 'creates an error if a channel integration is missing a manifest' do
-    requirements = double('AppFile', relative_path: 'requirements.json',
-                                     read: '{ "channel_integrations": { "channel_one": {} }}')
-    package = double('Package', files: [requirements])
-    errors = ZendeskAppsSupport::Validations::Requirements.call(package)
+  context 'a channel integration is missing a manifest' do
+    let(:requirements_string) { '{ "channel_integrations": { "channel_one": {} }}' }
 
-    expect(errors.first.key).to eq(:missing_required_fields)
-    expect(errors.first.data).to eq({ field: 'manifest_url', identifier: 'channel_one' })
+    it 'creates an error' do
+      expect(errors.first.key).to eq(:missing_required_fields)
+      expect(errors.first.data).to eq({ field: 'manifest_url', identifier: 'channel_one' })
+    end
   end
 end

--- a/zendesk_apps_support.gemspec
+++ b/zendesk_apps_support.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'i18n'
   s.add_runtime_dependency 'sass'
   s.add_runtime_dependency 'json'
-  s.add_runtime_dependency 'json-stream'
   s.add_runtime_dependency 'image_size'
   s.add_runtime_dependency 'erubis'
   s.add_runtime_dependency 'jshintrb', '~> 0.3.0'


### PR DESCRIPTION
- Removed `json-stream`: had implemented parallel functionality in NoOverrideHash, since that gem was only used in validating requirements.json let's not force it to every ZAT user.
- Removed require statements from being run before dependencies were needed, especially `sass`

Performance comparison:

### Master

```
ruby -rzendesk_apps_support -e ''  0.33s user 0.12s system 98% cpu 0.454 total
ruby -rzendesk_apps_support -e ''  0.33s user 0.11s system 98% cpu 0.453 total
ruby -rzendesk_apps_support -e ''  0.33s user 0.11s system 98% cpu 0.447 total
ruby -rzendesk_apps_support -e ''  0.35s user 0.12s system 98% cpu 0.482 total
ruby -rzendesk_apps_support -e ''  0.34s user 0.11s system 98% cpu 0.458 total
ruby -rzendesk_apps_support -e ''  0.33s user 0.11s system 98% cpu 0.453 total
ruby -rzendesk_apps_support -e ''  0.37s user 0.14s system 97% cpu 0.521 total
```

### This branch

```
ruby -rzendesk_apps_support -e ''  0.11s user 0.07s system 97% cpu 0.188 total
ruby -rzendesk_apps_support -e ''  0.12s user 0.08s system 97% cpu 0.197 total
ruby -rzendesk_apps_support -e ''  0.11s user 0.07s system 98% cpu 0.190 total
ruby -rzendesk_apps_support -e ''  0.11s user 0.07s system 97% cpu 0.189 total
ruby -rzendesk_apps_support -e ''  0.12s user 0.08s system 96% cpu 0.206 total
```

### Bonus control experiment

```
ruby -e ''  0.09s user 0.06s system 97% cpu 0.154 total
ruby -e ''  0.10s user 0.07s system 97% cpu 0.169 total
ruby -e ''  0.09s user 0.06s system 97% cpu 0.155 total
ruby -e ''  0.10s user 0.06s system 97% cpu 0.161 total
ruby -e ''  0.09s user 0.06s system 97% cpu 0.158 total
```

cc @zendesk/wombat @zendesk/vegemite 