### PR TITLE
Add icons to src.js so we don't have to guess in lotus!

### DIFF
--- a/lib/zendesk_apps_support/assets/src.js.erb
+++ b/lib/zendesk_apps_support/assets/src.js.erb
@@ -19,6 +19,7 @@ var app = ZendeskApps.defineApp(<%= iframe_only ? 'null' : 'source' %>)
   .reopen({
     appName: <%= name.to_json %>,
     appVersion: <%= version.to_json %>,
+    locationIcons: <%= location_icons.to_json %>,
     assetUrlPrefix: <%= asset_url_prefix.to_json %>,
     appClassName: <%= app_class_name.to_json %>,
     author: {

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -282,7 +282,7 @@ module ZendeskAppsSupport
     def location_icons
       {}.tap do |location_icons|
         manifest.locations.each do |host, locations_for_host|
-          next unless ['support'].include?(host)
+          next unless [Product::SUPPORT.name].include?(host)
 
           locations_for_host.keys.each do |location|
             next unless ['top_bar', 'nav_bar'].include?(location)

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -131,6 +131,7 @@ module ZendeskAppsSupport
         source: source,
         app_settings: app_settings,
         asset_url_prefix: asset_url_prefix,
+        location_icons: location_icons,
         app_class_name: app_class_name,
         author: manifest.author,
         translations: runtime_translations(translations_for(locale)),
@@ -276,6 +277,30 @@ module ZendeskAppsSupport
 
     def app_js
       read_file('app.js')
+    end
+
+    def location_icons
+      {}.tap do |location_icons|
+        manifest.locations.each do |host, locations_for_host|
+          next unless ['support'].include?(host)
+
+          locations_for_host.keys.each do |location|
+            next unless ['top_bar', 'nav_bar'].include?(location)
+            location_icons[host] ||= {}
+            location_icons[host][location] = if (has_file?("assets/icon_#{location}.svg"))
+              { 'svg' => "icon_#{location}.svg" }
+            elsif (has_file?("assets/icon_#{location}_inactive.png"))
+              {
+                'inactive' => "icon_#{location}_inactive.png",
+                'active' => has_file?("assets/icon_#{location}_active.png") ? "icon_#{location}_active.png" : "icon_#{location}_inactive.png",
+                'hover' => has_file?("assets/icon_#{location}_hover.png") ? "icon_#{location}_hover.png" : "icon_#{location}_inactive.png"
+              }
+            else
+              {}
+            end
+          end
+        end
+      end
     end
 
     def commonjs_modules

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -15,6 +15,8 @@ module ZendeskAppsSupport
     DEFAULT_SCSS   = File.read(File.expand_path('../assets/default_styles.scss', __FILE__))
     SRC_TEMPLATE   = Erubis::Eruby.new(File.read(File.expand_path('../assets/src.js.erb', __FILE__)))
 
+    LOCATIONS_WITH_ICONS = ['top_bar', 'nav_bar']
+
     attr_reader :lib_root, :root, :warnings
 
     def initialize(dir, is_cached = true)
@@ -285,7 +287,7 @@ module ZendeskAppsSupport
           next unless [Product::SUPPORT.name].include?(host)
 
           locations_for_host.keys.each do |location|
-            next unless ['top_bar', 'nav_bar'].include?(location)
+            next unless LOCATIONS_WITH_ICONS.include?(location)
             location_icons[host] ||= {}
             location_icons[host][location] = if (has_file?("assets/icon_#{location}.svg"))
               { 'svg' => "icon_#{location}.svg" }

--- a/spec/fixtures/iframe_app.js
+++ b/spec/fixtures/iframe_app.js
@@ -3,6 +3,7 @@ var app = ZendeskApps.defineApp(null)
   .reopen({
     appName: "ABC",
     appVersion: "1.0.0",
+    locationIcons: {},
     assetUrlPrefix: "http://localhost:4567/0/",
     appClassName: "app-0",
     author: {

--- a/spec/fixtures/legacy_app_en.js
+++ b/spec/fixtures/legacy_app_en.js
@@ -41,6 +41,7 @@ var app = ZendeskApps.defineApp(source)
   .reopen({
     appName: "ABC",
     appVersion: "1.0.0",
+    locationIcons: {},
     assetUrlPrefix: "http://localhost:4567/0/",
     appClassName: "app-0",
     author: {

--- a/spec/fixtures/legacy_app_nl.js
+++ b/spec/fixtures/legacy_app_nl.js
@@ -41,6 +41,7 @@ var app = ZendeskApps.defineApp(source)
   .reopen({
     appName: "EFG",
     appVersion: "1.0.0",
+    locationIcons: {},
     assetUrlPrefix: "http://localhost:4567/2/",
     appClassName: "app-1",
     author: {

--- a/spec/fixtures/legacy_app_no_template.js
+++ b/spec/fixtures/legacy_app_no_template.js
@@ -41,6 +41,7 @@ var app = ZendeskApps.defineApp(source)
   .reopen({
     appName: "ABC",
     appVersion: "1.0.0",
+    locationIcons: {},
     assetUrlPrefix: "http://localhost:4567/0/",
     appClassName: "app-0",
     author: {

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -350,4 +350,78 @@ describe ZendeskAppsSupport::Package do
       it { expect(modules).not_to be nil }
     end
   end
+
+  describe '#location_icons' do
+    before do
+      allow(package.manifest).to receive(:locations) { { 'support' => { 'top_bar' => 'someurl' } } }
+    end
+
+    context 'when it has a svg' do
+      it 'returns correct location_icons hash' do
+        allow(package).to receive(:has_file?) { |file| file == 'assets/icon_top_bar.svg' }
+        expect(package.send(:location_icons)).to eq( {
+          "support" => {
+            "top_bar" => {
+              'svg' => "icon_top_bar.svg"
+            }
+          }
+        })
+      end
+    end
+
+    context 'when it has three pngs' do
+      it 'returns correct location_icons hash' do
+        allow(package).to receive(:has_file?) { |file| file != 'assets/icon_top_bar.svg' }
+        expect(package.send(:location_icons)).to eq( {
+          "support" => {
+            "top_bar" => {
+              'active' => "icon_top_bar_active.png",
+              'inactive' => "icon_top_bar_inactive.png",
+              'hover' => "icon_top_bar_hover.png"
+            }
+          }
+        })
+      end
+    end
+
+    context 'when it only has inactive pngs' do
+      it 'returns correct location_icons hash' do
+        allow(package).to receive(:has_file?) { |file| file == 'assets/icon_top_bar_inactive.png' }
+        expect(package.send(:location_icons)).to eq( {
+          "support" => {
+            "top_bar" => {
+              'active' => "icon_top_bar_inactive.png",
+              'inactive' => "icon_top_bar_inactive.png",
+              'hover' => "icon_top_bar_inactive.png"
+            }
+          }
+        })
+      end
+    end
+
+
+    context 'when it has pngs and svgs' do
+      it 'returns correct location_icons hash' do
+        allow(package).to receive(:has_file?) { true }
+        expect(package.send(:location_icons)).to eq( {
+          "support" => {
+            "top_bar" => {
+              'svg' => "icon_top_bar.svg"
+            }
+          }
+        })
+      end
+    end
+
+    context 'when it has no images' do
+      it 'returns correct location_icons hash' do
+        allow(package).to receive(:has_file?) { false }
+        expect(package.send(:location_icons)).to eq( {
+          "support" => {
+            "top_bar" => {}
+          }
+        })
+      end
+    end
+  end
 end

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -353,16 +353,22 @@ describe ZendeskAppsSupport::Package do
 
   describe '#location_icons' do
     before do
-      allow(package.manifest).to receive(:locations) { { 'support' => { 'top_bar' => 'someurl' } } }
+      allow(package.manifest).to receive(:locations) { {
+        'chat' => { 'other_location' => '' },
+        'support' => { 'top_bar' => 'some_url', 'nav_bar' => 'other_url', 'ticket_sidebar' => 'last_url' } }
+      }
     end
 
-    context 'when it has a svg' do
-      it 'returns correct location_icons hash' do
-        allow(package).to receive(:has_file?) { |file| file == 'assets/icon_top_bar.svg' }
+    context 'when it has an svg' do
+      it 'returns correct location_icons hash for top_bar' do
+        allow(package).to receive(:has_file?) { |file| file == 'assets/icon_top_bar.svg' || file == 'assets/icon_nav_bar.svg' }
         expect(package.send(:location_icons)).to eq( {
           "support" => {
             "top_bar" => {
               'svg' => "icon_top_bar.svg"
+            },
+            "nav_bar" => {
+              'svg' => "icon_nav_bar.svg"
             }
           }
         })
@@ -371,13 +377,18 @@ describe ZendeskAppsSupport::Package do
 
     context 'when it has three pngs' do
       it 'returns correct location_icons hash' do
-        allow(package).to receive(:has_file?) { |file| file != 'assets/icon_top_bar.svg' }
+        allow(package).to receive(:has_file?) { |file| file != 'assets/icon_top_bar.svg' && file != 'assets/icon_nav_bar.svg'}
         expect(package.send(:location_icons)).to eq( {
           "support" => {
             "top_bar" => {
               'active' => "icon_top_bar_active.png",
               'inactive' => "icon_top_bar_inactive.png",
               'hover' => "icon_top_bar_hover.png"
+            },
+            "nav_bar" => {
+              'active' => "icon_nav_bar_active.png",
+              'inactive' => "icon_nav_bar_inactive.png",
+              'hover' => "icon_nav_bar_hover.png"
             }
           }
         })
@@ -386,13 +397,18 @@ describe ZendeskAppsSupport::Package do
 
     context 'when it only has inactive pngs' do
       it 'returns correct location_icons hash' do
-        allow(package).to receive(:has_file?) { |file| file == 'assets/icon_top_bar_inactive.png' }
+        allow(package).to receive(:has_file?) { |file| file == 'assets/icon_top_bar_inactive.png' || file == 'assets/icon_nav_bar_inactive.png' }
         expect(package.send(:location_icons)).to eq( {
           "support" => {
             "top_bar" => {
               'active' => "icon_top_bar_inactive.png",
               'inactive' => "icon_top_bar_inactive.png",
               'hover' => "icon_top_bar_inactive.png"
+            },
+            "nav_bar" => {
+              'active' => "icon_nav_bar_inactive.png",
+              'inactive' => "icon_nav_bar_inactive.png",
+              'hover' => "icon_nav_bar_inactive.png"
             }
           }
         })
@@ -407,6 +423,9 @@ describe ZendeskAppsSupport::Package do
           "support" => {
             "top_bar" => {
               'svg' => "icon_top_bar.svg"
+            },
+            "nav_bar" => {
+              'svg' => "icon_nav_bar.svg"
             }
           }
         })
@@ -418,7 +437,8 @@ describe ZendeskAppsSupport::Package do
         allow(package).to receive(:has_file?) { false }
         expect(package.send(:location_icons)).to eq( {
           "support" => {
-            "top_bar" => {}
+            "top_bar" => {},
+            "nav_bar" => {}
           }
         })
       end


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
We supply icons from ZAS now, so host products don't have to guess and have them hardcoded!
Also, way more flexible.

### References
* JIRA: 

### Risks