### PR TITLE
Add frameworkOptions to manifest

### DIFF
--- a/lib/zendesk_apps_support/manifest.rb
+++ b/lib/zendesk_apps_support/manifest.rb
@@ -8,6 +8,7 @@ module ZendeskAppsSupport
       marketing_only: 'marketingOnly',
       version: 'version',
       author: 'author',
+      framework_options: 'frameworkOptions',
       framework_version: 'frameworkVersion',
       single_install: 'singleInstall',
       signed_urls: 'signedUrls',
@@ -78,6 +79,7 @@ module ZendeskAppsSupport
       @signed_urls ||= false
       @no_template ||= false
       set_locations_and_hosts
+      set_framework_options
     end
 
     private
@@ -99,6 +101,15 @@ module ZendeskAppsSupport
           @used_hosts = ['support']
           { 'support' => {} }
         end
+    end
+
+    def set_framework_options
+      @framework_options ||= {
+        noTemplate: no_template_locations,
+        singleInstall: single_install?,
+        signedUrls: signed_urls?
+      }
+      framework_options.merge!(location: locations)
     end
 
     def replace_legacy_locations(original_locations)

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -118,12 +118,9 @@ module ZendeskAppsSupport
       # if no_template is an array, we still need the templates
       templates = manifest.no_template == true ? {} : compiled_templates(app_id, asset_url_prefix)
 
-      app_settings = {
-        location: manifest.locations,
-        noTemplate: manifest.no_template_locations,
-        singleInstall: manifest.single_install?,
-        signedUrls: manifest.signed_urls?
-      }.select { |_k, v| !v.nil? }
+      app_settings = manifest.framework_options.reject do |k, v|
+        k.to_s.start_with?('reopen') || v.nil?
+      end
 
       SRC_TEMPLATE.result(
         name: name,

--- a/spec/fixtures/iframe_app.js
+++ b/spec/fixtures/iframe_app.js
@@ -1,5 +1,5 @@
 var app = ZendeskApps.defineApp(null)
-  .reopenClass({"location":{"chat":{"chat_sidebar":"https://apps.zopim.com/time-tracking/"}},"noTemplate":[],"singleInstall":false,"signedUrls":false})
+  .reopenClass({"noTemplate":[],"singleInstall":false,"signedUrls":false,"location":{"chat":{"chat_sidebar":"https://apps.zopim.com/time-tracking/"}}})
   .reopen({
     appName: "ABC",
     appVersion: "1.0.0",

--- a/spec/fixtures/legacy_app_en.js
+++ b/spec/fixtures/legacy_app_en.js
@@ -37,7 +37,7 @@ module.exports = b;
 ;
 }
 var app = ZendeskApps.defineApp(source)
-  .reopenClass({"location":{"support":{"ticket_sidebar":"_legacy"}},"noTemplate":[],"singleInstall":false,"signedUrls":false})
+  .reopenClass({"noTemplate":[],"singleInstall":false,"signedUrls":false,"location":{"support":{"ticket_sidebar":"_legacy"}}})
   .reopen({
     appName: "ABC",
     appVersion: "1.0.0",

--- a/spec/fixtures/legacy_app_nl.js
+++ b/spec/fixtures/legacy_app_nl.js
@@ -37,7 +37,7 @@ module.exports = b;
 ;
 }
 var app = ZendeskApps.defineApp(source)
-  .reopenClass({"location":{"support":{"ticket_sidebar":"_legacy"}},"noTemplate":[],"singleInstall":false,"signedUrls":false})
+  .reopenClass({"noTemplate":[],"singleInstall":false,"signedUrls":false,"location":{"support":{"ticket_sidebar":"_legacy"}}})
   .reopen({
     appName: "EFG",
     appVersion: "1.0.0",

--- a/spec/fixtures/legacy_app_no_template.js
+++ b/spec/fixtures/legacy_app_no_template.js
@@ -37,7 +37,7 @@ module.exports = b;
 ;
 }
 var app = ZendeskApps.defineApp(source)
-  .reopenClass({"location":{"support":{"ticket_sidebar":"_legacy"}},"noTemplate":["ticket_sidebar"],"singleInstall":false,"signedUrls":false})
+  .reopenClass({"noTemplate":["ticket_sidebar"],"singleInstall":false,"signedUrls":false,"location":{"support":{"ticket_sidebar":"_legacy"}}})
   .reopen({
     appName: "ABC",
     appVersion: "1.0.0",

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -167,6 +167,30 @@ describe ZendeskAppsSupport::Manifest do
     end
   end
 
+  describe '#framework_options' do
+    context 'when frameworkOptions is missing from the manifest' do
+      it 'returns a hash of top-level settings' do
+        expect(manifest.framework_options).to be_a Hash
+        expect(manifest.framework_options[:location]).to eq manifest.locations
+        expect(manifest.framework_options[:singleInstall]).to eq manifest_hash[:singleInstall]
+        expect(manifest.framework_options[:signedUrls]).to eq manifest_hash[:signedUrls]
+      end
+    end
+
+    context 'when frameworkOptions is present' do
+      before do
+        manifest_hash[:frameworkOptions] = { signedUrls: true }
+      end
+
+      it 'returns the frameworkOptions' do
+        options = stringify_keys[manifest.framework_options]
+        expect(options['location']).to eq manifest.locations
+        expect(options['singleInstall']).to be_nil
+        expect(options['signedUrls']).to eq true
+      end
+    end
+  end
+
   describe '#location?' do
     context 'when locations are not supplied in the manifest' do
       before do

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -72,7 +72,10 @@ describe ZendeskAppsSupport::Package do
     end
 
     it 'should generate js with manifest noTemplate set to array' do
-      allow(@package.manifest).to receive(:no_template) { ['ticket_sidebar'] }
+      json = JSON.parse(File.read('spec/app/manifest.json'))
+      json['noTemplate'] = ['ticket_sidebar']
+      allow(@package).to receive(:read_file).and_call_original
+      allow(@package).to receive(:read_file).with('manifest.json').and_return(JSON.dump(json))
       js = @package.compile_js(app_name: "ABC", app_id: 0, assets_dir: 'http://localhost:4567/0/')
       expected = File.read('spec/fixtures/legacy_app_no_template.js')
       expect(js).to eq(expected)


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Add `frameworkOptions` to manifest, with the intention that we can add more options to it and they get passed through directly to ZAF without further ZAS changes. `noTemplate`, `singleInstall` and `signedUrls` will be supported on the root for backwards compatibility.

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-504

### Risks
* low: locations, signed urls, or single install parameters go wonky