### PR TITLE
Add experiments option to manifest available to ZAF

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,7 +55,7 @@ en:
               not allowed when an iframe URI or noTemplate is specified
             invalid_default_locale: "%{default_locale} is not a valid default locale."
             missing_translation_file: 'Missing translation file for locale ''%{default_locale}''.
-              Please read: http://developer.zendesk.com/documentation/apps/i18n.html'
+              Learn more: http://developer.zendesk.com/documentation/apps/i18n.html'
             invalid_host: "%{host_name} is an invalid host for apps."
             invalid_location:
               one: "%{invalid_locations} is an invalid location in %{host_name}."
@@ -83,7 +83,7 @@ en:
             invalid_type_parameter:
               one: "%{invalid_types} is an invalid parameter type."
               other: "%{invalid_types} are invalid parameter types."
-            unacceptable_boolean: '%{field} must be a Boolean value, got "%{value}"'
+            unacceptable_boolean: '%{field} must be a boolean value, got "%{value}".'
             invalid_no_template: noTemplate must be set to true, false, or an array
               of valid locations.
             duplicate_reference: 'Duplicate reference in manifest: "%{key}".'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,7 +20,7 @@ en:
             manifest_not_json: manifest is not proper JSON. %{errors}
             missing_manifest: Could not find manifest.json
             symlink_in_zip: Symlinks are not allowed in the zip file
-            experiment_not_public: 'Manifest specifies unknown or unavailable experiment:
+            invalid_experiment: 'Manifest specifies unknown or unavailable experiment:
               %{experiment}'
             missing_requirements: Could not find requirements.json
             requirements_not_supported: App requirements are not supported for marketing-only

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,8 @@ en:
             manifest_not_json: manifest is not proper JSON. %{errors}
             missing_manifest: Could not find manifest.json
             symlink_in_zip: Symlinks are not allowed in the zip file
+            experiment_not_public: 'Manifest specifies unknown or unavailable experiment:
+              %{experiment}'
             missing_requirements: Could not find requirements.json
             requirements_not_supported: App requirements are not supported for marketing-only
               apps

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -45,8 +45,8 @@ parts:
       title: "App builder job: symlinks not allowed. https://en.wikipedia.org/wiki/Symbolic_link"
       value: "Symlinks are not allowed in the zip file"
   - translation:
-      key: "txt.apps.admin.error.app_build.experiment_not_public"
-      title: "App builder job: experiment has been specifed that is not publically available or otherwise unknown"
+      key: "txt.apps.admin.error.app_build.invalid_experiment"
+      title: "App builder job: experiment has been specifed that is not publically available or otherwise invalid"
       value: "Manifest specifies unknown or unavailable experiment: %{experiment}"
   - translation:
       key: "txt.apps.admin.error.app_build.missing_requirements"

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -45,6 +45,10 @@ parts:
       title: "App builder job: symlinks not allowed. https://en.wikipedia.org/wiki/Symbolic_link"
       value: "Symlinks are not allowed in the zip file"
   - translation:
+      key: "txt.apps.admin.error.app_build.experiment_not_public"
+      title: "App builder job: experiment has been specifed that is not publically available or otherwise unknown"
+      value: "Manifest specifies unknown or unavailable experiment: %{experiment}"
+  - translation:
       key: "txt.apps.admin.error.app_build.missing_requirements"
       title: "App builder job: missing requirements error"
       value: "Could not find requirements.json"

--- a/lib/zendesk_apps_support/manifest.rb
+++ b/lib/zendesk_apps_support/manifest.rb
@@ -67,6 +67,10 @@ module ZendeskAppsSupport
       end
     end
 
+    def enabled_experiments
+      (experiments || {}).select { |k, v| v }.keys
+    end
+
     def initialize(manifest_text)
       m = parse_json(manifest_text)
       RUBY_TO_JSON.each do |ruby, json|

--- a/lib/zendesk_apps_support/manifest.rb
+++ b/lib/zendesk_apps_support/manifest.rb
@@ -8,6 +8,7 @@ module ZendeskAppsSupport
       marketing_only: 'marketingOnly',
       version: 'version',
       author: 'author',
+      experiments: 'experiments',
       framework_version: 'frameworkVersion',
       single_install: 'singleInstall',
       signed_urls: 'signedUrls',
@@ -77,6 +78,7 @@ module ZendeskAppsSupport
       @private = m.fetch('private', true)
       @signed_urls ||= false
       @no_template ||= false
+      @experiments ||= {}
       set_locations_and_hosts
     end
 

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -27,10 +27,9 @@ module ZendeskAppsSupport
 
     def validate(marketplace: true)
       [].tap do |errors|
-        errors << Validations::Marketplace.call(self) if marketplace
-
         errors << Validations::Manifest.call(self)
         if has_manifest?
+          errors << Validations::Marketplace.call(self) if marketplace
           errors << Validations::Source.call(self)
           errors << Validations::Translations.call(self)
           errors << Validations::Requirements.call(self)

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -119,6 +119,7 @@ module ZendeskAppsSupport
       templates = manifest.no_template == true ? {} : compiled_templates(app_id, asset_url_prefix)
 
       app_settings = {
+        experiments: manifest.experiments,
         location: manifest.locations,
         noTemplate: manifest.no_template_locations,
         singleInstall: manifest.single_install?,

--- a/lib/zendesk_apps_support/validations/marketplace.rb
+++ b/lib/zendesk_apps_support/validations/marketplace.rb
@@ -18,9 +18,9 @@ module ZendeskAppsSupport
         end
 
         def no_experiments(manifest)
-          non_public_experiments = manifest.enabled_experiments - WHITELISTED_EXPERIMENTS
-          non_public_experiments.map do |experiment|
-            ValidationError.new(:experiment_not_public, experiment: experiment)
+          invalid_experiments = manifest.enabled_experiments - WHITELISTED_EXPERIMENTS
+          invalid_experiments.map do |experiment|
+            ValidationError.new(:invalid_experiment, experiment: experiment)
           end
         end
       end

--- a/lib/zendesk_apps_support/validations/marketplace.rb
+++ b/lib/zendesk_apps_support/validations/marketplace.rb
@@ -1,9 +1,11 @@
 module ZendeskAppsSupport
   module Validations
     module Marketplace
+      WHITELISTED_EXPERIMENTS = [].freeze
+
       class << self
         def call(package)
-          [no_symlinks(package.root)].compact
+          [no_symlinks(package.root), *no_experiments(package.manifest)].compact
         end
 
         private
@@ -13,6 +15,13 @@ module ZendeskAppsSupport
             return ValidationError.new(:symlink_in_zip)
           end
           nil
+        end
+
+        def no_experiments(manifest)
+          non_public_experiments = manifest.enabled_experiments - WHITELISTED_EXPERIMENTS
+          non_public_experiments.map do |experiment|
+            ValidationError.new(:experiment_not_public, experiment: experiment)
+          end
         end
       end
     end

--- a/spec/fixtures/iframe_app.js
+++ b/spec/fixtures/iframe_app.js
@@ -1,5 +1,5 @@
 var app = ZendeskApps.defineApp(null)
-  .reopenClass({"location":{"chat":{"chat_sidebar":"https://apps.zopim.com/time-tracking/"}},"noTemplate":[],"singleInstall":false,"signedUrls":false})
+  .reopenClass({"experiments":{"hashParams":true},"location":{"chat":{"chat_sidebar":"https://apps.zopim.com/time-tracking/"}},"noTemplate":[],"singleInstall":false,"signedUrls":false})
   .reopen({
     appName: "ABC",
     appVersion: "1.0.0",

--- a/spec/fixtures/iframe_only_app/manifest.json
+++ b/spec/fixtures/iframe_only_app/manifest.json
@@ -8,5 +8,8 @@
   "defaultLocale": "en",
   "private": true,
   "location": { "zopim": { "chat_sidebar": "https://apps.zopim.com/time-tracking/" } },
+  "experiments": {
+    "hashParams": true
+  },
   "frameworkVersion": "2.0"
 }

--- a/spec/fixtures/legacy_app_en.js
+++ b/spec/fixtures/legacy_app_en.js
@@ -37,7 +37,7 @@ module.exports = b;
 ;
 }
 var app = ZendeskApps.defineApp(source)
-  .reopenClass({"location":{"support":{"ticket_sidebar":"_legacy"}},"noTemplate":[],"singleInstall":false,"signedUrls":false})
+  .reopenClass({"experiments":{},"location":{"support":{"ticket_sidebar":"_legacy"}},"noTemplate":[],"singleInstall":false,"signedUrls":false})
   .reopen({
     appName: "ABC",
     appVersion: "1.0.0",

--- a/spec/fixtures/legacy_app_nl.js
+++ b/spec/fixtures/legacy_app_nl.js
@@ -37,7 +37,7 @@ module.exports = b;
 ;
 }
 var app = ZendeskApps.defineApp(source)
-  .reopenClass({"location":{"support":{"ticket_sidebar":"_legacy"}},"noTemplate":[],"singleInstall":false,"signedUrls":false})
+  .reopenClass({"experiments":{},"location":{"support":{"ticket_sidebar":"_legacy"}},"noTemplate":[],"singleInstall":false,"signedUrls":false})
   .reopen({
     appName: "EFG",
     appVersion: "1.0.0",

--- a/spec/fixtures/legacy_app_no_template.js
+++ b/spec/fixtures/legacy_app_no_template.js
@@ -37,7 +37,7 @@ module.exports = b;
 ;
 }
 var app = ZendeskApps.defineApp(source)
-  .reopenClass({"location":{"support":{"ticket_sidebar":"_legacy"}},"noTemplate":["ticket_sidebar"],"singleInstall":false,"signedUrls":false})
+  .reopenClass({"experiments":{},"location":{"support":{"ticket_sidebar":"_legacy"}},"noTemplate":["ticket_sidebar"],"singleInstall":false,"signedUrls":false})
   .reopen({
     appName: "ABC",
     appVersion: "1.0.0",

--- a/spec/fixtures/symlinks/manifest.json
+++ b/spec/fixtures/symlinks/manifest.json
@@ -1,0 +1,1 @@
+../iframe_only_app/manifest.json

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -35,7 +35,10 @@ describe ZendeskAppsSupport::Manifest do
           required: Faker::Boolean.boolean,
           secure: Faker::Boolean.boolean
         }
-      ]
+      ],
+      experiments: {
+        hashParams: true
+      }
     }
   end
 
@@ -67,7 +70,17 @@ describe ZendeskAppsSupport::Manifest do
       expect(manifest.default_locale).to eq manifest_hash[:defaultLocale]
       expect(manifest.original_locations).to eq stringify_keys[manifest_hash[:location]]
       expect(manifest.oauth).to eq manifest_hash[:oauth]
+      expect(manifest.experiments).to eq stringify_keys[manifest_hash[:experiments]]
       expect(manifest.original_parameters).to eq manifest_hash[:parameters].map(&stringify_keys)
+    end
+  end
+
+  describe '#experiments' do
+    context 'when no experiments are declared' do
+      it 'returns an empty hash' do
+        manifest_hash.delete(:experiments) { |key| raise "Manifest should have had #{key}" }
+        expect(manifest.experiments).to eq({})
+      end
     end
   end
 

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -301,7 +301,7 @@ describe ZendeskAppsSupport::Validations::Manifest do
   end
 
   it 'should have an error when a non-boolean is passed for a field that must be boolean' do
-    expect(create_package('singleInstall' => 'false')).to have_error(/must be a Boolean value/)
+    expect(create_package('singleInstall' => 'false')).to have_error(/must be a boolean value/)
   end
 
   it 'should have an error when noTemplate is not a boolean or an array' do

--- a/spec/validations/marketplace_spec.rb
+++ b/spec/validations/marketplace_spec.rb
@@ -24,8 +24,8 @@ describe ZendeskAppsSupport::Validations::Marketplace do
       package
     end
 
-    it 'raises experiment_not_public validation error' do
-      expect(errors[0].key).to eq(:experiment_not_public)
+    it 'raises invalid_experiment validation error' do
+      expect(errors[0].key).to eq(:invalid_experiment)
       expect(errors[0].message).to match(/unavailable experiment: explodingButtons/)
       expect(errors[1].message).to match(/unavailable experiment: punnyTickets/)
     end

--- a/spec/validations/marketplace_spec.rb
+++ b/spec/validations/marketplace_spec.rb
@@ -1,10 +1,34 @@
 require 'spec_helper'
 
 describe ZendeskAppsSupport::Validations::Marketplace do
-  let(:package) { ZendeskAppsSupport::Package.new('spec/fixtures/symlinks') }
   let(:errors) { ZendeskAppsSupport::Validations::Marketplace.call(package) }
 
-  it 'should raise error when symlink exists inside the app for the marketplace' do
-    expect(errors.first.key).to eq(:symlink_in_zip)
+  context 'with package with symlinks in it' do
+    let(:package) { ZendeskAppsSupport::Package.new('spec/fixtures/symlinks') }
+
+    it 'should raise error when symlink exists inside the app for the marketplace' do
+      expect(errors.first.key).to eq(:symlink_in_zip)
+    end
   end
+
+  context 'with package with non-whitelisted experiments' do
+    let(:manifest) { ZendeskAppsSupport::Manifest.new(JSON.dump(manifest_hash)) }
+    let(:manifest_hash) do
+      json = JSON.parse(File.read('spec/fixtures/iframe_only_app/manifest.json'))
+      json['experiments'] = { explodingButtons: true, punnyTickets: true }
+      json
+    end
+    let(:package) do
+      package = ZendeskAppsSupport::Package.new('spec/fixtures/iframe_only_app')
+      allow(package).to receive(:manifest).and_return(manifest)
+      package
+    end
+
+    it 'raises experiment_not_public validation error' do
+      expect(errors[0].key).to eq(:experiment_not_public)
+      expect(errors[0].message).to match(/unavailable experiment: explodingButtons/)
+      expect(errors[1].message).to match(/unavailable experiment: punnyTickets/)
+    end
+  end
+
 end


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Add experiments option to manifest available to ZAF

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-504

### Risks
* low: breaks app serialization