### PR TITLE
AF-526 modals don't work with signed URLs

### DIFF
--- a/lib/zendesk_apps_support/location.rb
+++ b/lib/zendesk_apps_support/location.rb
@@ -27,7 +27,8 @@ module ZendeskAppsSupport
       Location.new(id: 5, orderable: true, name: 'user_sidebar', product_code: Product::SUPPORT.code),
       Location.new(id: 6, orderable: true, name: 'organization_sidebar', product_code: Product::SUPPORT.code),
       Location.new(id: 7, orderable: false, name: 'background', product_code: Product::SUPPORT.code),
-      Location.new(id: 8, orderable: true, name: 'chat_sidebar', product_code: Product::CHAT.code)
+      Location.new(id: 8, orderable: true, name: 'chat_sidebar', product_code: Product::CHAT.code),
+      Location.new(id: 9, orderable: false, name: 'modal', product_code: Product::SUPPORT.code)
     ].freeze
   end
 end

--- a/lib/zendesk_apps_support/location.rb
+++ b/lib/zendesk_apps_support/location.rb
@@ -3,12 +3,14 @@ module ZendeskAppsSupport
     extend ZendeskAppsSupport::Finders
     attr_reader :id, :name, :orderable, :product_code
 
-    IDS = Set.new
+    def self.unique_ids
+      @ids ||= Set.new
+    end
 
     def initialize(attrs)
       @id = attrs.fetch(:id)
-      raise 'Duplicate id' if IDS.include? @id
-      IDS.add @id
+      raise 'Duplicate id' if Location.unique_ids.include? @id
+      Location.unique_ids.add @id
       @name = attrs.fetch(:name)
       @orderable = attrs.fetch(:orderable)
       @product_code = attrs.fetch(:product_code)

--- a/lib/zendesk_apps_support/location.rb
+++ b/lib/zendesk_apps_support/location.rb
@@ -3,8 +3,12 @@ module ZendeskAppsSupport
     extend ZendeskAppsSupport::Finders
     attr_reader :id, :name, :orderable, :product_code
 
+    IDS = Set.new
+
     def initialize(attrs)
       @id = attrs.fetch(:id)
+      raise 'Duplicate id' if IDS.include? @id
+      IDS.add @id
       @name = attrs.fetch(:name)
       @orderable = attrs.fetch(:orderable)
       @product_code = attrs.fetch(:product_code)

--- a/lib/zendesk_apps_support/manifest.rb
+++ b/lib/zendesk_apps_support/manifest.rb
@@ -68,7 +68,7 @@ module ZendeskAppsSupport
     end
 
     def enabled_experiments
-      (experiments || {}).select { |k, v| v }.keys
+      (experiments || {}).select { |_k, v| v }.keys
     end
 
     def initialize(manifest_text)


### PR DESCRIPTION
### Description

Add the modal location so that we can store the URL to redirect for signing.
cc @zendesk/vegemite 

### References

https://zendesk.atlassian.net/browse/AF-526

### Risks
- [low] failing app uploads / updates