### PR TITLE
Add location for editor apps

### DIFF
--- a/lib/zendesk_apps_support/location.rb
+++ b/lib/zendesk_apps_support/location.rb
@@ -27,7 +27,8 @@ module ZendeskAppsSupport
       Location.new(id: 5, orderable: true, name: 'user_sidebar', product_code: Product::SUPPORT.code),
       Location.new(id: 6, orderable: true, name: 'organization_sidebar', product_code: Product::SUPPORT.code),
       Location.new(id: 7, orderable: false, name: 'background', product_code: Product::SUPPORT.code),
-      Location.new(id: 8, orderable: true, name: 'chat_sidebar', product_code: Product::CHAT.code)
+      Location.new(id: 8, orderable: true, name: 'chat_sidebar', product_code: Product::CHAT.code),
+      Location.new(id: 9, orderable: false, name: 'ticket_editor', product_code: Product::SUPPORT.code)
     ].freeze
   end
 end


### PR DESCRIPTION
cc @zendesk/wombat @zendesk/orchid 

Once we get https://github.com/zendesk/zendesk_console/pull/12267 merged back into lotus, we will want to be able to indicate the 'ticket_editor' location to test out the new editor app location.

Wombats: can we redeploy ZAS once this is reviewed? 