### PR TITLE
[AF-527] Support location objects in manifest

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,8 +60,6 @@ en:
             invalid_location:
               one: "%{invalid_locations} is an invalid location in %{host_name}."
               other: "%{invalid_locations} are invalid locations in %{host_name}."
-            cant_use_uri_with_no_iframe: "%{location} location cannot specify both
-              a URI and the noIframe option."
             blank_location_uri: "%{location} location does not specify a URI."
             invalid_location_uri: "%{uri} is either an invalid location URI, refers
               to a missing asset, or does not use HTTPS."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,9 @@ en:
             invalid_location:
               one: "%{invalid_locations} is an invalid location in %{host_name}."
               other: "%{invalid_locations} are invalid locations in %{host_name}."
+            cant_use_uri_with_no_iframe: "%{location} location cannot specify both
+              a URI and the noIframe option."
+            blank_location_uri: "%{location} location does not specify a URI."
             invalid_location_uri: "%{uri} is either an invalid location URI, refers
               to a missing asset, or does not use HTTPS."
             duplicate_location:

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -145,10 +145,6 @@ parts:
       title: "App builder job: invalid locations"
       value: "%{invalid_locations} are invalid locations in %{host_name}."
   - translation:
-      key: "txt.apps.admin.error.app_build.cant_use_uri_with_no_iframe"
-      title: "App builder job: invalid location object as URI is specified along with no iframe option in the manifest"
-      value: "%{location} location cannot specify both a URI and the noIframe option."
-  - translation:
       key: "txt.apps.admin.error.app_build.blank_location_uri"
       title: "App builder job: invalid URI for an iframe in the manifest"
       value: "%{location} location does not specify a URI."

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -145,6 +145,14 @@ parts:
       title: "App builder job: invalid locations"
       value: "%{invalid_locations} are invalid locations in %{host_name}."
   - translation:
+      key: "txt.apps.admin.error.app_build.cant_use_uri_with_no_iframe"
+      title: "App builder job: invalid location object as URI is specified along with no iframe option in the manifest"
+      value: "%{location} location cannot specify both a URI and the noIframe option."
+  - translation:
+      key: "txt.apps.admin.error.app_build.blank_location_uri"
+      title: "App builder job: invalid URI for an iframe in the manifest"
+      value: "%{location} location does not specify a URI."
+  - translation:
       key: "txt.apps.admin.error.app_build.invalid_location_uri"
       title: "App builder job: invalid URI for an iframe in the manifest"
       value: "%{uri} is either an invalid location URI, refers to a missing asset, or does not use HTTPS."

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -158,11 +158,10 @@ module ZendeskAppsSupport
 
             locations.each do |location_key, location|
               url = location['url']
-              no_iframe = location.fetch('noIframe', false)
+              auto_load = location.fetch('autoLoad', true)
               if url && !url.empty?
-                errors << ValidationError.new(:cant_use_uri_with_no_iframe, location: location_key) if no_iframe
                 errors << invalid_location_uri_error(package, location['url'])
-              elsif !no_iframe
+              elsif auto_load
                 errors << ValidationError.new(:blank_location_uri, location: location_key)
               end
             end

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -156,8 +156,8 @@ module ZendeskAppsSupport
                                   count: invalid_locations.length)
             end
 
-            locations.values.each do |path|
-              errors << invalid_location_uri_error(package, path)
+            locations.values.each do |location|
+              errors << invalid_location_uri_error(package, location['url'])
             end
           end
 
@@ -248,10 +248,10 @@ module ZendeskAppsSupport
         def location_framework_mismatch(manifest)
           locations = manifest.locations
           stub = ZendeskAppsSupport::Manifest::LEGACY_URI_STUB
-          iframe_locations = locations_any?(locations) do |url|
+          iframe_locations = locations_any_url?(locations) do |url|
             url != stub
           end
-          legacy_locations = (!iframe_locations && manifest.location?) || locations_any?(locations) do |url|
+          legacy_locations = (!iframe_locations && manifest.location?) || locations_any_url?(locations) do |url|
             url == stub
           end
           if manifest.iframe_only?
@@ -261,9 +261,9 @@ module ZendeskAppsSupport
           end
         end
 
-        def locations_any?(locations)
+        def locations_any_url?(locations)
           locations.values.any? do |location_hash|
-            location_hash.values.any? { |url| yield(url) }
+            location_hash.values.any? { |location| yield(location['url']) }
           end
         end
 

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -156,8 +156,15 @@ module ZendeskAppsSupport
                                   count: invalid_locations.length)
             end
 
-            locations.values.each do |location|
-              errors << invalid_location_uri_error(package, location['url'])
+            locations.each do |location_key, location|
+              url = location['url']
+              no_iframe = location.fetch('noIframe', false)
+              if url && !url.empty?
+                errors << ValidationError.new(:cant_use_uri_with_no_iframe, location: location_key) if no_iframe
+                errors << invalid_location_uri_error(package, location['url'])
+              elsif !no_iframe
+                errors << ValidationError.new(:blank_location_uri, location: location_key)
+              end
             end
           end
 

--- a/spec/fixtures/iframe_app.js
+++ b/spec/fixtures/iframe_app.js
@@ -1,5 +1,5 @@
 var app = ZendeskApps.defineApp(null)
-  .reopenClass({"experiments":{"hashParams":true},"location":{"chat":{"chat_sidebar":"https://apps.zopim.com/time-tracking/"}},"noTemplate":[],"singleInstall":false,"signedUrls":false})
+  .reopenClass({"experiments":{"hashParams":true},"location":{"chat":{"chat_sidebar":{"url":"https://apps.zopim.com/time-tracking/"}}},"noTemplate":[],"singleInstall":false,"signedUrls":false})
   .reopen({
     appName: "ABC",
     appVersion: "1.0.0",

--- a/spec/fixtures/legacy_app_en.js
+++ b/spec/fixtures/legacy_app_en.js
@@ -37,7 +37,7 @@ module.exports = b;
 ;
 }
 var app = ZendeskApps.defineApp(source)
-  .reopenClass({"experiments":{},"location":{"support":{"ticket_sidebar":"_legacy"}},"noTemplate":[],"singleInstall":false,"signedUrls":false})
+  .reopenClass({"experiments":{},"location":{"support":{"ticket_sidebar":{"url":"_legacy"}}},"noTemplate":[],"singleInstall":false,"signedUrls":false})
   .reopen({
     appName: "ABC",
     appVersion: "1.0.0",

--- a/spec/fixtures/legacy_app_nl.js
+++ b/spec/fixtures/legacy_app_nl.js
@@ -37,7 +37,7 @@ module.exports = b;
 ;
 }
 var app = ZendeskApps.defineApp(source)
-  .reopenClass({"experiments":{},"location":{"support":{"ticket_sidebar":"_legacy"}},"noTemplate":[],"singleInstall":false,"signedUrls":false})
+  .reopenClass({"experiments":{},"location":{"support":{"ticket_sidebar":{"url":"_legacy"}}},"noTemplate":[],"singleInstall":false,"signedUrls":false})
   .reopen({
     appName: "EFG",
     appVersion: "1.0.0",

--- a/spec/fixtures/legacy_app_no_template.js
+++ b/spec/fixtures/legacy_app_no_template.js
@@ -37,7 +37,7 @@ module.exports = b;
 ;
 }
 var app = ZendeskApps.defineApp(source)
-  .reopenClass({"experiments":{},"location":{"support":{"ticket_sidebar":"_legacy"}},"noTemplate":["ticket_sidebar"],"singleInstall":false,"signedUrls":false})
+  .reopenClass({"experiments":{},"location":{"support":{"ticket_sidebar":{"url":"_legacy"}}},"noTemplate":["ticket_sidebar"],"singleInstall":false,"signedUrls":false})
   .reopen({
     appName: "ABC",
     appVersion: "1.0.0",

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -21,11 +21,17 @@ describe ZendeskAppsSupport::Manifest do
       defaultLocale: Faker::Address.country_code,
       location: {
         support: {
-          new_ticket_sidebar: Faker::Internet.url,
-          top_bar: Faker::Internet.url
+          new_ticket_sidebar: {
+            url: Faker::Internet.url
+          },
+          top_bar: {
+            url: Faker::Internet.url
+          }
         },
         chat: {
-          main_panel: Faker::Internet.url
+          main_panel: {
+            url: Faker::Internet.url
+          }
         }
       },
       parameters: [
@@ -219,16 +225,48 @@ describe ZendeskAppsSupport::Manifest do
     it 'supports strings' do
       manifest_hash[:location] = 'ticket_sidebar'
       location_object = manifest.locations
-      expect(location_object).to eq('support' => { 'ticket_sidebar' => '_legacy' })
+      expect(location_object).to eq(
+        'support' => { 'ticket_sidebar' => { 'url' => '_legacy' } }
+      )
     end
 
     it 'supports arrays' do
       manifest_hash[:location] = %w(🔔 🃏)
       location_object = manifest.locations
-      expect(location_object).to eq('support' => { '🃏' => '_legacy', '🔔' => '_legacy' })
+      expect(location_object).to eq(
+        'support' => {
+          '🃏' => { 'url' => '_legacy' },
+          '🔔' => { 'url' => '_legacy' }
+        }
+      )
     end
 
-    it 'supports objects' do
+    it 'supports objects with string urls' do
+      manifest_hash[:location] = stringify_keys[{
+        support: {
+          ticket_sidebar: 'https://my-site.org/'
+        },
+        chat: {
+          main_panel: 'https://your-site.org/'
+        }
+      }]
+      location_object = manifest.locations
+
+      expect(location_object).to eq(
+        'support' => {
+          'ticket_sidebar' => {
+            'url' => 'https://my-site.org/'
+          }
+        },
+        'chat' => {
+          'main_panel' => {
+            'url' => 'https://your-site.org/'
+          }
+        }
+      )
+    end
+
+    it 'supports objects with objects' do
       location_object = manifest.locations
 
       expect(location_object).to eq stringify_keys[manifest_hash[:location]]
@@ -237,39 +275,35 @@ describe ZendeskAppsSupport::Manifest do
     it 'canonicalises zendesk to support' do
       manifest_hash[:location] = stringify_keys[{
         zendesk: {
-          ticket_sidebar: 'https://my-site.org/'
-        },
-        chat: {
-          main_panel: 'https://your-site.org/'
+          ticket_sidebar: {
+            url: 'https://my-site.org/'
+          }
         }
       }]
 
       expect(manifest.locations).to eq(
         'support' => {
-          'ticket_sidebar' => 'https://my-site.org/'
-        },
-        'chat' => {
-          'main_panel' => 'https://your-site.org/'
+          'ticket_sidebar' => {
+            'url' => 'https://my-site.org/'
+          }
         }
       )
     end
 
     it 'canonicalises zopim to chat' do
       manifest_hash[:location] = stringify_keys[{
-        zendesk: {
-          ticket_sidebar: 'https://my-site.org/'
-        },
         zopim: {
-          main_panel: 'https://your-site.org/'
+          main_panel: {
+            url: 'https://your-site.org/'
+          }
         }
       }]
 
       expect(manifest.locations).to eq(
-        'support' => {
-          'ticket_sidebar' => 'https://my-site.org/'
-        },
         'chat' => {
-          'main_panel' => 'https://your-site.org/'
+          'main_panel' => {
+            'url' => 'https://your-site.org/'
+          }
         }
       )
     end

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -216,9 +216,9 @@ describe ZendeskAppsSupport::Validations::Manifest do
     end
   end
 
-  context 'location is noIframe' do
+  context 'location is manual load and has no uri' do
     before do
-      @manifest_hash = { 'location' => { 'zendesk' => { 'ticket_sidebar' => { 'noIframe' => true } } } }
+      @manifest_hash = { 'location' => { 'zendesk' => { 'ticket_sidebar' => { 'autoLoad' => false } } } }
     end
 
     it 'should not have a location error' do
@@ -228,13 +228,15 @@ describe ZendeskAppsSupport::Validations::Manifest do
     end
   end
 
-  context 'location is noIframe and specifies references a url' do
+  context 'location is manual load and specifies references a url' do
     before do
-      @manifest_hash = { 'location' => { 'zendesk' => { 'ticket_sidebar' => { 'noIframe' => true, 'url' => 'https://i.am.so.conf/used/setup.exe' } } } }
+      @manifest_hash = { 'location' => { 'zendesk' => { 'ticket_sidebar' => { 'autoLoad' => false, 'url' => 'https://i.am.so.conf/used/setup.exe' } } } }
     end
 
     it 'should not have a location error' do
-      expect(@package).to have_error(/cannot specify both a URI and the noIframe option/)
+      expect(@package).not_to have_error(/invalid location/)
+      expect(@package).not_to have_error(/cannot specify both a URI and the noIframe option/)
+      expect(@package).not_to have_error(/location does not specify a URI/)
     end
   end
 

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -196,6 +196,48 @@ describe ZendeskAppsSupport::Validations::Manifest do
     end
   end
 
+  context 'location references a correct URI' do
+    before do
+      @manifest_hash = { 'location' => { 'zendesk' => { 'ticket_sidebar' => { 'url' => 'https://mysite.com/zendesk_iframe' } } } }
+    end
+
+    it 'should not have a location error' do
+      expect(@package).not_to have_error(/invalid location/)
+    end
+  end
+
+  context 'location uri is blank' do
+    before do
+      @manifest_hash = { 'location' => { 'zendesk' => { 'ticket_sidebar' => '' } } }
+    end
+
+    it 'should not have a location error' do
+      expect(@package).to have_error(/location does not specify a URI/)
+    end
+  end
+
+  context 'location is noIframe' do
+    before do
+      @manifest_hash = { 'location' => { 'zendesk' => { 'ticket_sidebar' => { 'noIframe' => true } } } }
+    end
+
+    it 'should not have a location error' do
+      expect(@package).not_to have_error(/invalid location/)
+      expect(@package).not_to have_error(/cannot specify both a URI and the noIframe option/)
+      expect(@package).not_to have_error(/location does not specify a URI/)
+    end
+  end
+
+  context 'location is noIframe and specifies references a url' do
+    before do
+      @manifest_hash = { 'location' => { 'zendesk' => { 'ticket_sidebar' => { 'noIframe' => true, 'url' => 'https://i.am.so.conf/used/setup.exe' } } } }
+    end
+
+    it 'should not have a location error' do
+      expect(@package).to have_error(/cannot specify both a URI and the noIframe option/)
+    end
+  end
+
   context 'location references a file outside of assets folder' do
     before do
       @manifest_hash = { 'location' => { 'zendesk' => { 'ticket_sidebar' => 'manifest.json' } } }


### PR DESCRIPTION
:v: 

/cc @zendesk/vegemite

⛔️ **depends on https://github.com/zendesk/zendesk_app_framework/pull/657** ⛔️ 

### Description
Support location objects in manifest
e.g. 
```
{
  "location": {
    "support": {
      "background": {
        "url": "assets/iframe.html"
      },
      "nav_bar": {
        "url": "assets/iframe.html",
        "autoHide": true
      },
      "ticket_sidebar": {
        "url": "assets/iframe.html",
        "autoLoad": false
      },
      "new_ticket_sidebar": {
        "autoLoad": false
      }
    }
}
```

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-527

### Risks
* medium: generates source with a different location format