### PR TITLE
No cache the svgs in ZAT

### DIFF
--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -288,7 +288,8 @@ module ZendeskAppsSupport
             next unless LOCATIONS_WITH_ICONS.include?(location)
             location_icons[host] ||= {}
             location_icons[host][location] = if (has_file?("assets/icon_#{location}.svg"))
-              { 'svg' => "icon_#{location}.svg" }
+              disable_cache = "?#{Time.now.to_i}" unless @is_cached
+              { 'svg' => "icon_#{location}.svg#{disable_cache}" }
             elsif (has_file?("assets/icon_#{location}_inactive.png"))
               {
                 'inactive' => "icon_#{location}_inactive.png",

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -288,8 +288,8 @@ module ZendeskAppsSupport
             next unless LOCATIONS_WITH_ICONS.include?(location)
             location_icons[host] ||= {}
             location_icons[host][location] = if (has_file?("assets/icon_#{location}.svg"))
-              disable_cache = "?#{Time.now.to_i}" unless @is_cached
-              { 'svg' => "icon_#{location}.svg#{disable_cache}" }
+              cache_busting_param = "?#{Time.now.to_i}" unless @is_cached
+              { 'svg' => "icon_#{location}.svg#{cache_busting_param}" }
             elsif (has_file?("assets/icon_#{location}_inactive.png"))
               {
                 'inactive' => "icon_#{location}_inactive.png",


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
svgSprite in zendesk_console caches the svg icons. This is super annoying in ZAT mode, so we append the time in seconds to mitigate this.

### References
* JIRA: 

### Risks