### PR TITLE
dont double-declare constants

### DIFF
--- a/lib/zendesk_apps_support/validations/source.rb
+++ b/lib/zendesk_apps_support/validations/source.rb
@@ -15,9 +15,8 @@ module ZendeskAppsSupport
         sub: true,
 
         # predefined globals:
-        predef: %w(_ console services helpers alert confirm window document self
-                   JSON Base64 clearInterval clearTimeout setInterval setTimeout
-                   require module exports top frames parent moment),
+        predef: %w(_ console services helpers alert confirm self
+                   JSON Base64 require module exports moment),
 
         browser: true
       }.freeze

--- a/spec/validations/source_spec.rb
+++ b/spec/validations/source_spec.rb
@@ -107,6 +107,19 @@ describe ZendeskAppsSupport::Validations::Source do
     expect(errors).to be_nil
   end
 
+  it 'should not have a jslint error when using globals' do
+    source = double(
+      'AppFile',
+      relative_path: 'app.js',
+      read: 'var a = [window, document, self, clearInterval, clearTimeout, '\
+            'setInterval, setTimeout, top, frames, parent];'
+    )
+    allow(package).to receive(:js_files) { [source] }
+    errors = ZendeskAppsSupport::Validations::Source.call(package)
+
+    expect(errors).to be_nil
+  end
+
   it 'should have a jslint error when missing semicolon in lib js file' do
     package = ZendeskAppsSupport::Package.new('spec/invalid_app')
     errors  = ZendeskAppsSupport::Validations::Source.call(package)


### PR DESCRIPTION
### Description

Cleanup of some variables that are also allowed by telling JSHint to validate for the browser environment.

cc @zendesk/vegemite

### Risks

- [medium] unexpected JSHint errors in v1 apps