### PR TITLE
[APPS-3271] Ensure requirements only apps specify Support as their product

### DIFF
--- a/lib/zendesk_apps_support/manifest.rb
+++ b/lib/zendesk_apps_support/manifest.rb
@@ -47,9 +47,13 @@ module ZendeskAppsSupport
 
     def products
       @products ||=
-        location_options.map { |lo| lo.location.product_code }
-                        .uniq
-                        .map { |code| Product.find_by(code: code) }
+        if requirements_only?
+          [ Product::SUPPORT ]
+        else
+          location_options.map { |lo| lo.location.product_code }
+                          .uniq
+                          .map { |code| Product.find_by(code: code) }
+        end
     end
 
     def location_options

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -210,6 +210,19 @@ describe ZendeskAppsSupport::Manifest do
     end
   end
 
+  describe '#products' do
+    context 'for a requirements only app' do
+      before do
+        manifest_hash.delete(:locations)
+        manifest_hash[:requirementsOnly] = true
+      end
+
+      it 'returns Support' do
+        expect(manifest.products).to eq([ ZendeskAppsSupport::Product::SUPPORT ])
+      end
+    end
+  end
+
   describe '#locations' do
     it 'supports strings' do
       manifest_hash[:location] = 'ticket_sidebar'


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Ensure requirements only apps specify Support as their product. This is to pass validations that the app can be uploaded from within Support.

### References
* JIRA: https://zendesk.atlassian.net/browse/APPS-3271

### Risks
* low: breaks product-related validations / features