### PR TITLE
[AF-425] Set products for no location apps

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,12 @@ SpaceInsideBrackets:
 Style/Alias:
   Enabled: false
 
+Style/IndentArray:
+  Enabled: false
+
+Style/IndentHash:
+  Enabled: false
+
 HashSyntax:
   EnforcedStyle: ruby19
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,10 +10,11 @@ en:
               one: 'JSHint error in %{file}: %{errors}'
               other: 'JSHint errors in %{file}: %{errors}'
             no_template_deprecated_in_v2: 'noTemplate is deprecated and cannot be
-              used with frameworkVersion 2 or above. Set the autoLoad or autoHide
+              used with framework version 2 or above. Set the autoLoad or autoHide
               property for each specific location instead. Learn more: %{link}.'
             no_parameters_required: Parameters can't be defined for marketing-only
               apps
+            marketing_only_app_cant_be_private: Marketing-only apps must not be private
             no_location_required: Locations can't be defined when you specify requirements
               only
             no_framework_version_required: Framework versions can't be set when you

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -24,6 +24,10 @@ parts:
       title: "App builder job: prevent adding parameters while marketing only"
       value: "Parameters can't be defined for marketing-only apps"
   - translation:
+      key: "txt.apps.admin.error.app_build.marketing_only_app_cant_be_private"
+      title: "App builder job: prevent creating a private marketing only app"
+      value: "Marketing-only apps must not be private"
+  - translation:
       key: "txt.apps.admin.error.app_build.no_location_required"
       title: "App builder job: ban location while requirements only"
       value: "Locations can't be defined when you specify requirements only"

--- a/lib/zendesk_apps_support/manifest.rb
+++ b/lib/zendesk_apps_support/manifest.rb
@@ -47,7 +47,7 @@ module ZendeskAppsSupport
 
     def products
       @products ||=
-        if requirements_only?
+        if requirements_only? || marketing_only?
           [ Product::SUPPORT ]
         else
           location_options.map { |lo| lo.location.product_code }

--- a/lib/zendesk_apps_support/manifest.rb
+++ b/lib/zendesk_apps_support/manifest.rb
@@ -50,9 +50,7 @@ module ZendeskAppsSupport
         if requirements_only? || marketing_only?
           [ Product::SUPPORT ]
         else
-          location_options.map { |lo| lo.location.product_code }
-                          .uniq
-                          .map { |code| Product.find_by(code: code) }
+          products_from_locations
         end
     end
 
@@ -133,6 +131,12 @@ module ZendeskAppsSupport
     private
 
     attr_reader :locations
+
+    def products_from_locations
+      location_options.map { |lo| lo.location.product_code }
+                      .uniq
+                      .map { |code| Product.find_by(code: code) }
+    end
 
     def set_locations_and_hosts
       @locations =

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -22,6 +22,7 @@ module ZendeskAppsSupport
 
         private
 
+        # rubocop:disable Metrics/AbcSize
         def collate_manifest_errors(package)
           manifest = package.manifest
 
@@ -33,6 +34,7 @@ module ZendeskAppsSupport
 
           if manifest.marketing_only?
             errors << ban_parameters(manifest)
+            errors << private_marketing_app_error(manifest)
           else
             errors << parameters_error(manifest)
             errors << invalid_hidden_parameter_error(manifest)
@@ -57,6 +59,7 @@ module ZendeskAppsSupport
 
           errors.flatten.compact
         end
+        # rubocop:enable Metrics/AbcSize
 
         def boolean_error(manifest)
           booleans = %i(requirements_only marketing_only single_install signed_urls private)
@@ -98,6 +101,10 @@ module ZendeskAppsSupport
 
         def ban_framework_version(manifest)
           ValidationError.new(:no_framework_version_required) unless manifest.framework_version.nil?
+        end
+
+        def private_marketing_app_error(manifest)
+          ValidationError.new(:marketing_only_app_cant_be_private) if manifest.private?
         end
 
         def oauth_error(manifest)

--- a/spec/fixtures/marketing_only_app/manifest.json
+++ b/spec/fixtures/marketing_only_app/manifest.json
@@ -5,5 +5,6 @@
     "email": "support@zendesk.com"
   },
   "defaultLocale": "en",
-  "marketingOnly": true
+  "marketingOnly": true,
+  "private": false
 }

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -7,6 +7,7 @@ describe ZendeskAppsSupport::Manifest do
   let(:manifest_hash) do
     {
       name: Faker::App.name,
+      marketingOnly: Faker::Boolean.boolean,
       requirementsOnly: Faker::Boolean.boolean,
       version: Faker::App.version,
       private: true,
@@ -66,6 +67,8 @@ describe ZendeskAppsSupport::Manifest do
     it 'should return values from the passed in JSON string' do
       expect(manifest.requirements_only).to eq manifest_hash[:requirementsOnly]
       expect(manifest.requirements_only?).to eq manifest_hash[:requirementsOnly]
+      expect(manifest.marketing_only).to eq manifest_hash[:marketingOnly]
+      expect(manifest.marketing_only?).to eq manifest_hash[:marketingOnly]
       expect(manifest.version).to eq manifest_hash[:version]
       expect(manifest.author).to eq stringify_keys[manifest_hash[:author]]
       expect(manifest.framework_version).to eq manifest_hash[:frameworkVersion]
@@ -211,13 +214,36 @@ describe ZendeskAppsSupport::Manifest do
   end
 
   describe '#products' do
+    before do
+      manifest_hash.delete(:marketingOnly)
+      manifest_hash.delete(:requirementsOnly)
+    end
+
+    it 'derives the products from the locations' do
+      expect(manifest.products).to eq([
+        ZendeskAppsSupport::Product::SUPPORT,
+        ZendeskAppsSupport::Product::CHAT
+      ])
+    end
+
     context 'for a requirements only app' do
       before do
-        manifest_hash.delete(:locations)
+        manifest_hash.delete(:location)
         manifest_hash[:requirementsOnly] = true
       end
 
-      it 'returns Support' do
+      it 'is overriden to Support' do
+        expect(manifest.products).to eq([ ZendeskAppsSupport::Product::SUPPORT ])
+      end
+    end
+
+    context 'for a marketing only app' do
+      before do
+        manifest_hash.delete(:location)
+        manifest_hash[:marketingOnly] = true
+      end
+
+      it 'is overriden to Support' do
         expect(manifest.products).to eq([ ZendeskAppsSupport::Product::SUPPORT ])
       end
     end

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -241,6 +241,7 @@ describe ZendeskAppsSupport::Manifest do
       before do
         manifest_hash.delete(:location)
         manifest_hash[:marketingOnly] = true
+        manifest_hash[:private] = false
       end
 
       it 'is overriden to Support' do

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -127,9 +127,17 @@ describe ZendeskAppsSupport::Validations::Manifest do
       expect(errors).to be_empty
     end
 
+    it 'should have an error if private is not false' do
+      @manifest_hash = {
+        marketingOnly: true
+      }
+      expect(@package).to have_error(/Marketing-only apps must not be private/)
+    end
+
     it 'should have an error when parameters are specified' do
       @manifest_hash = {
         marketingOnly: true,
+        private: false,
         parameters: [
           'name' => 'foo'
         ]


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description

Hard-codes support for Zendesk Support product for `marketingOnly` apps (similar to #150), and adds validation that a marketing only app must not be private.

For reference, the old PR is here if anyone wants it: https://github.com/zendesk/zendesk_apps_support/compare/master...adammw/products-for-no-location-apps-bak


### References
* JIRA: https://zendesk.atlassian.net/browse/AF-425

### Risks
* low: could break products for marketing only apps (which don't use ZAS until https://github.com/zendesk/zendesk_app_market/pull/2000 anyway)