### PR TITLE
bump sassc to v1.11.2, pulling in latest release of libsass

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       jshintrb (~> 0.3.0)
       json
       sass
-      sassc (~> 1.11.0)
+      sassc (~> 1.11.2)
 
 GEM
   remote: https://rubygems.org/
@@ -21,14 +21,14 @@ GEM
     execjs (2.7.0)
     faker (1.6.6)
       i18n (~> 0.5)
-    ffi (1.9.14)
+    ffi (1.9.17)
     i18n (0.7.0)
     image_size (1.5.0)
     jshintrb (0.3.0)
       execjs
       multi_json (>= 1.3)
       rake
-    json (2.0.2)
+    json (2.0.3)
     multi_json (1.12.1)
     parser (2.3.3.0)
       ast (~> 2.2)
@@ -56,7 +56,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
     sass (3.4.23)
-    sassc (1.11.1)
+    sassc (1.11.2)
       bundler
       ffi (~> 1.9.6)
       sass (>= 3.3.0)

--- a/zendesk_apps_support.gemspec
+++ b/zendesk_apps_support.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
 
   s.add_runtime_dependency 'i18n'
-  s.add_runtime_dependency 'sassc', '~> 1.11.0'
+  s.add_runtime_dependency 'sassc', '~> 1.11.2'
   s.add_runtime_dependency 'sass' # remove explicit dependency when all compilation uses SassC
   s.add_runtime_dependency 'json'
   s.add_runtime_dependency 'image_size'


### PR DESCRIPTION
### Description

Updates sassc bumping libsass from v3.4.1 to v3.4.3: https://github.com/sass/libsass/releases

cc @zendesk/vegemite 

### Risks

- crashes in v1 apps using the newCssCompiler experiment