### PR TITLE
Add organization fields as a resource type in app requirements

### DIFF
--- a/lib/zendesk_apps_support/app_requirement.rb
+++ b/lib/zendesk_apps_support/app_requirement.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module ZendeskAppsSupport
   class AppRequirement
-    TYPES = %w(automations channel_integrations macros targets views ticket_fields triggers user_fields organization_fields).freeze
+    TYPES = %w(automations channel_integrations
+    macros targets views ticket_fields triggers
+    user_fields organization_fields).freeze
   end
 end

--- a/lib/zendesk_apps_support/app_requirement.rb
+++ b/lib/zendesk_apps_support/app_requirement.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module ZendeskAppsSupport
   class AppRequirement
-    TYPES = %w(automations channel_integrations macros targets views ticket_fields triggers user_fields).freeze
+    TYPES = %w(automations channel_integrations macros targets views ticket_fields triggers user_fields organization_fields).freeze
   end
 end

--- a/lib/zendesk_apps_support/app_requirement.rb
+++ b/lib/zendesk_apps_support/app_requirement.rb
@@ -2,7 +2,7 @@
 module ZendeskAppsSupport
   class AppRequirement
     TYPES = %w(automations channel_integrations
-    macros targets views ticket_fields triggers
-    user_fields organization_fields).freeze
+               macros targets views ticket_fields triggers
+               user_fields organization_fields).freeze
   end
 end

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -56,7 +56,7 @@ module ZendeskAppsSupport
           user_fields = requirements['user_fields'] || {}
           organization_fields = requirements['organization_fields'] || {}
           custom_fields = user_fields.merge(organization_fields)
-          return unless custom_fields
+          return if custom_fields.empty?
           [].tap do |errors|
             custom_fields.each do |identifier, fields|
               next if fields.include? 'key'

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -53,14 +53,15 @@ module ZendeskAppsSupport
         end
 
         def invalid_custom_fields(requirements)
-          user_fields = requirements['user_fields'] || {}
-          organization_fields = requirements['organization_fields'] || {}
-          custom_fields = user_fields.merge(organization_fields)
-          return if custom_fields.empty?
+          user_fields = requirements['user_fields']
+          organization_fields = requirements['organization_fields']
+          return if user_fields.nil? && organization_fields.nil?
           [].tap do |errors|
-            custom_fields.each do |identifier, fields|
-              next if fields.include? 'key'
-              errors << ValidationError.new(:missing_required_fields, field: 'key', identifier: identifier)
+            [user_fields, organization_fields].compact.each do |field_group|
+              field_group.each do |identifier, fields|
+                next if fields.include? 'key'
+                errors << ValidationError.new(:missing_required_fields, field: 'key', identifier: identifier)
+              end
             end
           end
         end

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -24,7 +24,7 @@ module ZendeskAppsSupport
             errors << invalid_requirements_types(requirements)
             errors << excessive_requirements(requirements)
             errors << invalid_channel_integrations(requirements)
-            errors << invalid_user_fields(requirements)
+            errors << invalid_custom_fields(requirements)
             errors << missing_required_fields(requirements)
             errors.flatten!
             errors.compact!
@@ -52,11 +52,13 @@ module ZendeskAppsSupport
           ValidationError.new(:excessive_requirements, max: MAX_REQUIREMENTS, count: count) if count > MAX_REQUIREMENTS
         end
 
-        def invalid_user_fields(requirements)
+        def invalid_custom_fields(requirements)
           user_fields = requirements['user_fields']
-          return unless user_fields
+          organization_fields = requirements['organization_fields']
+          custom_fields = user_fields.concat(organization_fields)
+          return unless custom_fields
           [].tap do |errors|
-            user_fields.each do |identifier, fields|
+            custom_fields.each do |identifier, fields|
               next if fields.include? 'key'
               errors << ValidationError.new(:missing_required_fields, field: 'key', identifier: identifier)
             end

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -55,7 +55,7 @@ module ZendeskAppsSupport
         def invalid_custom_fields(requirements)
           user_fields = requirements['user_fields']
           organization_fields = requirements['organization_fields']
-          custom_fields = user_fields.merge(organization_fields)
+          custom_fields = {}.merge(user_fields).merge(organization_fields)
           return unless custom_fields
           [].tap do |errors|
             custom_fields.each do |identifier, fields|

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -53,9 +53,9 @@ module ZendeskAppsSupport
         end
 
         def invalid_custom_fields(requirements)
-          user_fields = requirements['user_fields']
-          organization_fields = requirements['organization_fields']
-          custom_fields = {}.merge(user_fields).merge(organization_fields)
+          user_fields = requirements['user_fields'] || {}
+          organization_fields = requirements['organization_fields'] || {}
+          custom_fields = user_fields.merge(organization_fields)
           return unless custom_fields
           [].tap do |errors|
             custom_fields.each do |identifier, fields|

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -55,7 +55,7 @@ module ZendeskAppsSupport
         def invalid_custom_fields(requirements)
           user_fields = requirements['user_fields']
           organization_fields = requirements['organization_fields']
-          custom_fields = user_fields.concat(organization_fields)
+          custom_fields = user_fields.merge(organization_fields)
           return unless custom_fields
           [].tap do |errors|
             custom_fields.each do |identifier, fields|

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -79,6 +79,30 @@ describe ZendeskAppsSupport::Validations::Requirements do
     end
   end
 
+  context 'a user field requirement is lacking required fields' do
+    let(:requirements_string) { JSON.generate('user_fields' => { 'abc' => {'type' => 'text', 'title' => 'abc'} }) }
+
+    it 'creates an error for missing required fields' do
+      expect(errors.first.key).to eq(:missing_required_fields)
+    end
+  end
+
+  context 'an org field requirement is lacking required fields' do
+    let(:requirements_string) { JSON.generate('organization_fields' => { 'abc' => {'type' => 'text', 'title' => 'abc'} }) }
+
+    it 'creates an error for missing required fields' do
+      expect(errors.first.key).to eq(:missing_required_fields)
+    end
+  end
+
+  context 'multiple custom field types are accepted with valid fields' do
+    let(:requirements_string) { JSON.generate( 'user_fields' => { 'abc' => {'type' => 'text', 'title' => 'abc', 'key' => 'abc' }}, 'organization_fields' => { 'xyz' => { 'type' => 'text', 'title' => 'xyz', 'key' => 'xyz' }} ) }
+    it 'passes with no errors' do
+      puts errors
+      expect(errors).to be_empty
+    end
+  end
+
   context 'many requirements are lacking required fields' do
     let(:requirements_string) { JSON.generate('targets' => { 'abc' => {}, 'xyz' => {} }) }
 

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -71,15 +71,15 @@ describe ZendeskAppsSupport::Validations::Requirements do
     end
   end
 
-  context 'a requirement is lacking required fields' do
+  context 'a requirement field missing a "key"' do
     let(:requirements_string) { JSON.generate('targets' => { 'abc' => {} }) }
 
-    it 'creates an error for any requirement that is lacking required fields' do
+    it 'creates an error for missing required fields' do
       expect(errors.first.key).to eq(:missing_required_fields)
     end
   end
 
-  context 'a user field requirement is lacking required fields' do
+  context 'a user field missing a "key"' do
     let(:requirements_string) do
       JSON.generate('user_fields' => { 'abc' => { 'type' => 'text', 'title' => 'abc' } })
     end
@@ -89,7 +89,7 @@ describe ZendeskAppsSupport::Validations::Requirements do
     end
   end
 
-  context 'an org field requirement is lacking required fields' do
+  context 'an org field missing a "key"' do
     let(:requirements_string) do
       JSON.generate('organization_fields' => { 'abc' => { 'type' => 'text', 'title' => 'abc' } })
     end
@@ -99,7 +99,7 @@ describe ZendeskAppsSupport::Validations::Requirements do
     end
   end
 
-  context 'multiple custom field types are accepted with valid fields' do
+  context 'multiple custom field types with valid fields' do
     let(:requirements_string) do
       JSON.generate(
         'user_fields' => {
@@ -116,7 +116,7 @@ describe ZendeskAppsSupport::Validations::Requirements do
     end
   end
 
-  context 'multiple custom field groups with duplicate nested keys are valid and do not overwrite each others errors' do
+  context 'multiple custom field groups with duplicate nested keys' do
     let(:requirements_string) do
       JSON.generate(
         'user_fields' => {
@@ -127,7 +127,7 @@ describe ZendeskAppsSupport::Validations::Requirements do
         }
       )
     end
-    it 'creates an error for missing required fields' do
+    it 'create an error for missing required fields' do
       expect(errors.first.key).to eq(:missing_required_fields)
     end
   end

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -80,7 +80,9 @@ describe ZendeskAppsSupport::Validations::Requirements do
   end
 
   context 'a user field requirement is lacking required fields' do
-    let(:requirements_string) { JSON.generate('user_fields' => { 'abc' => {'type' => 'text', 'title' => 'abc'} }) }
+    let(:requirements_string) do
+      JSON.generate('user_fields' => { 'abc' => { 'type' => 'text', 'title' => 'abc' } })
+    end
 
     it 'creates an error for missing required fields' do
       expect(errors.first.key).to eq(:missing_required_fields)
@@ -88,7 +90,9 @@ describe ZendeskAppsSupport::Validations::Requirements do
   end
 
   context 'an org field requirement is lacking required fields' do
-    let(:requirements_string) { JSON.generate('organization_fields' => { 'abc' => {'type' => 'text', 'title' => 'abc'} }) }
+    let(:requirements_string) do
+      JSON.generate('organization_fields' => { 'abc' => { 'type' => 'text', 'title' => 'abc' } })
+    end
 
     it 'creates an error for missing required fields' do
       expect(errors.first.key).to eq(:missing_required_fields)
@@ -96,7 +100,16 @@ describe ZendeskAppsSupport::Validations::Requirements do
   end
 
   context 'multiple custom field types are accepted with valid fields' do
-    let(:requirements_string) { JSON.generate( 'user_fields' => { 'abc' => {'type' => 'text', 'title' => 'abc', 'key' => 'abc' }}, 'organization_fields' => { 'xyz' => { 'type' => 'text', 'title' => 'xyz', 'key' => 'xyz' }} ) }
+    let(:requirements_string) do
+      JSON.generate(
+        'user_fields' => {
+          'abc' => { 'type' => 'text', 'title' => 'abc', 'key' => 'abc' }
+        },
+        'organization_fields' => {
+          'xyz' => { 'type' => 'text', 'title' => 'xyz', 'key' => 'xyz' }
+        }
+      )
+    end
     it 'passes with no errors' do
       puts errors
       expect(errors).to be_empty

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -116,6 +116,22 @@ describe ZendeskAppsSupport::Validations::Requirements do
     end
   end
 
+  context 'multiple custom field groups with duplicate nested keys are valid and do not overwrite each others errors' do
+    let(:requirements_string) do
+      JSON.generate(
+        'user_fields' => {
+          'abc' => { 'type' => 'text', 'title' => 'abc' }
+        },
+        'organization_fields' => {
+          'abc' => { 'type' => 'text', 'title' => 'abc', 'key' => 'abc' }
+        }
+      )
+    end
+    it 'creates an error for missing required fields' do
+      expect(errors.first.key).to eq(:missing_required_fields)
+    end
+  end
+
   context 'many requirements are lacking required fields' do
     let(:requirements_string) { JSON.generate('targets' => { 'abc' => {}, 'xyz' => {} }) }
 


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Add organization fields as a resource type in app requirements

### References
* JIRA: Related to testing https://zendesk.atlassian.net/browse/AF-577

### Risks
* [low] breaks validations for app requirements