### PR TITLE
special error message for when the entire app is nested in a directory

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,8 @@ en:
               app.js
             manifest_not_json: manifest is not proper JSON. %{errors}
             missing_manifest: Could not find manifest.json
+            nested_manifest: Could not find manifest.json in the root of the zip file,
+              but %{found_path} was found. Try re-creating the archive from this directory.
             symlink_in_zip: Symlinks are not allowed in the zip file
             invalid_experiment: 'Manifest specifies unknown or unavailable experiment:
               %{experiment}'

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -49,6 +49,10 @@ parts:
       title: "App builder job: missing manifest error"
       value: "Could not find manifest.json"
   - translation:
+      key: "txt.apps.admin.error.app_build.nested_manifest"
+      title: "App builder job: missing manifest error, but it was found in a subdirectory"
+      value: "Could not find manifest.json in the root of the zip file, but %{found_path} was found. Try re-creating the archive from this directory."
+  - translation:
       key: "txt.apps.admin.error.app_build.symlink_in_zip"
       title: "App builder job: symlinks not allowed. https://en.wikipedia.org/wiki/Symbolic_link"
       value: "Symlinks are not allowed in the zip file"

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -12,7 +12,13 @@ module ZendeskAppsSupport
 
       class << self
         def call(package)
-          return [ValidationError.new(:missing_manifest)] unless package.has_file?('manifest.json')
+          unless package.has_file?('manifest.json')
+            nested_manifest = package.files.find { |file| file =~ %r{\A[^/]+?/manifest\.json\Z} }
+            if nested_manifest
+              return [ValidationError.new(:nested_manifest, found_path: nested_manifest.relative_path)]
+            end
+            return [ValidationError.new(:missing_manifest)]
+          end
 
           collate_manifest_errors(package)
 

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -45,6 +45,11 @@ describe ZendeskAppsSupport::Validations::Manifest do
     expect(package).to have_error 'Could not find manifest.json'
   end
 
+  it 'should have an error when manifest.json is in a subdirectory' do
+    package = ZendeskAppsSupport::Package.new('spec/fixtures')
+    expect(package).to have_error(/Could not find manifest\.json in the root of the zip file, /)
+  end
+
   let(:manifest) { ZendeskAppsSupport::Manifest.new(JSON.dump(@manifest_hash)) }
 
   before do


### PR DESCRIPTION
### Description

People ask us on a semi-regular basis why their app won't upload and they get a missing `manifest.json` error. Often the reason is they zipped up a folder with everything else inside it, so there's no manifest in the root of the zip. Later we can just support that, but for now let's automate the answer we give people by a useful error message.

cc @zendesk/vegemite 

### Risks

- [low] failing app uploads