### PR TITLE
[OFFAPPS-814] case sensitive locale check

### DIFF
--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -213,7 +213,7 @@ module ZendeskAppsSupport
         def default_locale_error(manifest, package)
           default_locale = manifest.default_locale
           unless default_locale.nil?
-            if default_locale !~ Translations::VALID_LOCALE
+            if !Translations::VALID_LOCALES.include?(default_locale)
               ValidationError.new(:invalid_default_locale, default_locale: default_locale)
             elsif package.translation_files.detect { |f| f.relative_path == "translations/#{default_locale}.json" }.nil?
               ValidationError.new(:missing_translation_file, default_locale: default_locale)

--- a/lib/zendesk_apps_support/validations/translations.rb
+++ b/lib/zendesk_apps_support/validations/translations.rb
@@ -8,7 +8,7 @@ module ZendeskAppsSupport
       TRANSLATIONS_PATH = %r{^translations/(.*)\.json$}
                           # from https://support.zendesk.com/api/v2/locales/agent.json
                           # manually added 'en'
-      VALID_LOCALES     = %w{bg cs da de en en-CA en-GB en-US es es-419 es-ES fi fr fr-CA it ja ko nl no pl pt pt-BR ro ru sv tr uk zh-CN zh-TW}.freeze
+      VALID_LOCALES     = %w{ar bg cs da de en en-CA en-GB en-US es es-419 es-ES fi fr fr-CA it ja ko nl no pl pt pt-BR ro ru sv tr uk zh-CN zh-TW}.freeze
 
       class TranslationFormatError < StandardError
       end

--- a/lib/zendesk_apps_support/validations/translations.rb
+++ b/lib/zendesk_apps_support/validations/translations.rb
@@ -6,7 +6,9 @@ module ZendeskAppsSupport
   module Validations
     module Translations
       TRANSLATIONS_PATH = %r{^translations/(.*)\.json$}
-      VALID_LOCALE      = /^[a-z]{2}(-\w{2,3})?$/
+                          # from https://support.zendesk.com/api/v2/locales/agent.json
+                          # manually added 'en'
+      VALID_LOCALES     = %w{bg cs da de en en-CA en-GB en-US es es-419 es-ES fi fr fr-CA it ja ko nl no pl pt pt-BR ro ru sv tr uk zh-CN zh-TW}.freeze
 
       class TranslationFormatError < StandardError
       end
@@ -24,7 +26,7 @@ module ZendeskAppsSupport
         private
 
         def locale_error(file, locale)
-          return nil if VALID_LOCALE =~ locale
+          return nil if VALID_LOCALES.include?(locale)
           ValidationError.new('translation.invalid_locale', file: file.relative_path)
         end
 

--- a/spec/validations/translations_spec.rb
+++ b/spec/validations/translations_spec.rb
@@ -45,6 +45,17 @@ describe ZendeskAppsSupport::Validations::Translations do
     end
   end
 
+  context 'when there is a file with an incorrect capitalized locale for a name' do
+    let(:translation_files) do
+      [double('AppFile', relative_path: 'translations/en-us.json', read: '{}')]
+    end
+
+    it 'should report the error' do
+      expect(subject.length).to eq(1)
+      expect(subject[0].to_s).to match(/locale/)
+    end
+  end
+
   context 'when there is a file with a valid locale containing valid JSON' do
     let(:translation_files) do
       [double('AppFile', relative_path: 'translations/en-US.json', read: '{}')]


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
currently zat doesn't check case sensitive. And it doesn't check if we actually have that locale.

There is one downside of doing this. If we add a local we have to update ZAS (and ZAT/ZAM) before we can use it.

### References
* JIRA: https://zendesk.atlassian.net/browse/OFFAPPS-814

### Risks
[high] a lot of apps will fail this check (correctly!).