### PR TITLE
[AF-681] Add sunsetting warning when validating an app using ZAF v1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
       execjs
       multi_json (>= 1.3)
       rake
-    json (2.0.3)
+    json (2.1.0)
     multi_json (1.12.1)
     parser (2.3.3.0)
       ast (~> 2.2)
@@ -55,7 +55,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
-    sass (3.4.23)
+    sass (3.4.24)
     sassc (1.11.2)
       bundler
       ffi (~> 1.9.6)
@@ -74,4 +74,4 @@ DEPENDENCIES
   zendesk_apps_support!
 
 BUNDLED WITH
-   1.14.6
+   1.15.1

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,3 +115,6 @@ en:
             deprecated_version: You are targeting a deprecated version of the framework.
               Your app will work, but it might break when the new framework version
               is deployed.
+            sunsetting_version_v1: 'You are targeting the v1 framework, which is deprecated.
+              From August 1st 2017, no new v1 app submissions will be accepted. Consider
+              migrating to the v2 framework. For more information: https://support.zendesk.com/hc/articles/115004453028'

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -203,6 +203,10 @@ parts:
       title: "App builder job: deprecated version specified"
       value: 'You are targeting a deprecated version of the framework. Your app will work, but it might break when the new framework version is deployed.'
   - translation:
+      key: "txt.apps.admin.warning.app_build.sunsetting_version_v1"
+      title: "App builder job: sunsetting version v1 specified"
+      value: 'You are targeting the v1 framework, which is deprecated. From August 1st 2017, no new v1 app submissions will be accepted. Consider migrating to the v2 framework. For more information: https://support.zendesk.com/hc/articles/115004453028'
+  - translation:
       key: "txt.apps.admin.error.app_build.invalid_version"
       title: "App builder job: invalid framework version"
       value: "%{target_version} is not a valid framework version. Available versions are: %{available_versions}."

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -299,6 +299,10 @@ module ZendeskAppsSupport
             package.warnings << I18n.t('txt.apps.admin.warning.app_build.deprecated_version')
           end
 
+          if target_version == '1.0'
+            package.warnings << I18n.t('txt.apps.admin.warning.app_build.sunsetting_version_v1')
+          end
+
           unless valid_to_serve.include?(target_version)
             return ValidationError.new(:invalid_version,
                                        target_version: target_version,


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Displays a warning message if the manifest framework version is 1.0 when running `zat validate`

![image](https://user-images.githubusercontent.com/754567/27269253-c5d898d8-54f8-11e7-8dca-e4a2e9568adc.png)

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-681

### Risks
* [low] Message being added to terminal output if version number matches.