### PR TITLE
[AF-681] Add SUNSETTING and SUNSETTED

### DIFF
--- a/lib/zendesk_apps_support/app_version.rb
+++ b/lib/zendesk_apps_support/app_version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module ZendeskAppsSupport
-  # At any point in time, we support up to four types of versions:
+  # At any point in time, we support up to four versions:
   #  * deprecated -- we will still serve apps targeting the deprecated version,
   #                  but newly created or updated apps CANNOT target it
   #  * sunsetting -- we will soon be removing support for this version;
@@ -10,15 +10,14 @@ module ZendeskAppsSupport
   #  * future     -- we will serve apps targeting the future version;
   #                  newly created or updates apps MAY target it, but it
   #                  may change without notice
-  # Versions can be listed as strings or in arrays
   class AppVersion
     DEPRECATED = '0.5'
     SUNSETTING = '1.0'
     CURRENT    = '2.0'
     FUTURE     = nil
 
-    TO_BE_SERVED     = [DEPRECATED, SUNSETTING, CURRENT, FUTURE].compact.flatten.freeze
-    VALID_FOR_UPDATE = [SUNSETTING, CURRENT, FUTURE].compact.flatten.freeze
+    TO_BE_SERVED     = [DEPRECATED, SUNSETTING, CURRENT, FUTURE].compact.freeze
+    VALID_FOR_UPDATE = [SUNSETTING, CURRENT, FUTURE].compact.freeze
 
     attr_reader :current
 
@@ -38,11 +37,11 @@ module ZendeskAppsSupport
     end
 
     def deprecated?
-      DEPRECATED.include?(@version)
+      @version == DEPRECATED
     end
 
     def sunsetting?
-      SUNSETTING && SUNSETTING.include?(@version)
+      @version == SUNSETTING
     end
 
     def obsolete?

--- a/lib/zendesk_apps_support/app_version.rb
+++ b/lib/zendesk_apps_support/app_version.rb
@@ -22,8 +22,7 @@ module ZendeskAppsSupport
     attr_reader :current
 
     def initialize(version)
-      @version = version.to_s
-      @version.freeze
+      @version = version.to_s.freeze
       @current = CURRENT
       freeze
     end

--- a/lib/zendesk_apps_support/app_version.rb
+++ b/lib/zendesk_apps_support/app_version.rb
@@ -20,9 +20,12 @@ module ZendeskAppsSupport
     TO_BE_SERVED     = [DEPRECATED, SUNSETTING, CURRENT, FUTURE].compact.flatten.freeze
     VALID_FOR_UPDATE = [SUNSETTING, CURRENT, FUTURE].compact.flatten.freeze
 
+    attr_reader :current
+
     def initialize(version)
       @version = version.to_s
       @version.freeze
+      @current = CURRENT
       freeze
     end
 
@@ -40,10 +43,6 @@ module ZendeskAppsSupport
 
     def sunsetting?
       SUNSETTING && SUNSETTING.include?(@version)
-    end
-
-    def current
-      CURRENT
     end
 
     def obsolete?

--- a/lib/zendesk_apps_support/app_version.rb
+++ b/lib/zendesk_apps_support/app_version.rb
@@ -1,20 +1,24 @@
 # frozen_string_literal: true
 module ZendeskAppsSupport
-  # At any point in time, we support up to three versions:
+  # At any point in time, we support up to four types of versions:
   #  * deprecated -- we will still serve apps targeting the deprecated version,
   #                  but newly created or updated apps CANNOT target it
+  #  * sunsetting -- we will soon be removing support for this version;
+  #                  newly created or updated apps SHOULD target the current version
   #  * current    -- we will serve apps targeting the current version;
   #                  newly created or updated apps SHOULD target it
   #  * future     -- we will serve apps targeting the future version;
   #                  newly created or updates apps MAY target it, but it
   #                  may change without notice
+  # Versions can be listed as strings or in arrays
   class AppVersion
     DEPRECATED = '0.5'
-    CURRENT    = '1.0'
-    FUTURE     = '2.0'
+    SUNSETTING = '1.0'
+    CURRENT    = '2.0'
+    FUTURE     = nil
 
-    TO_BE_SERVED     = [DEPRECATED, CURRENT, FUTURE].compact.freeze
-    VALID_FOR_UPDATE = [CURRENT, FUTURE].compact.freeze
+    TO_BE_SERVED     = [DEPRECATED, SUNSETTING, CURRENT, FUTURE].compact.flatten.freeze
+    VALID_FOR_UPDATE = [SUNSETTING, CURRENT, FUTURE].compact.flatten.freeze
 
     def initialize(version)
       @version = version.to_s
@@ -31,7 +35,15 @@ module ZendeskAppsSupport
     end
 
     def deprecated?
-      @version == DEPRECATED
+      DEPRECATED.include?(@version)
+    end
+
+    def sunsetting?
+      SUNSETTING && SUNSETTING.include?(@version)
+    end
+
+    def current
+      CURRENT
     end
 
     def obsolete?

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -292,7 +292,7 @@ module ZendeskAppsSupport
         end
 
         def invalid_version_error(manifest, package)
-          valid_to_serve = AppVersion::TO_BE_SERVED.compact
+          valid_to_serve = AppVersion::TO_BE_SERVED
           target_version = manifest.framework_version
 
           if target_version == AppVersion::DEPRECATED

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -292,7 +292,7 @@ module ZendeskAppsSupport
         end
 
         def invalid_version_error(manifest, package)
-          valid_to_serve = AppVersion::TO_BE_SERVED
+          valid_to_serve = AppVersion::TO_BE_SERVED.compact
           target_version = manifest.framework_version
 
           if target_version == AppVersion::DEPRECATED


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Add support for arrays of versions as well as `sunsetting` and `sunsetted` versions.

This can be used to display warnings in ZAT, such as when running [`zat update`](https://github.com/zendesk/zendesk_apps_tools/pull/190).

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-681

### Risks
* [low] New methods being added