### PR TITLE
[APPS-3371] Add a new validation method and distinguish create from update

### DIFF
--- a/lib/zendesk_apps_support/app_version.rb
+++ b/lib/zendesk_apps_support/app_version.rb
@@ -4,7 +4,7 @@ module ZendeskAppsSupport
   #  * deprecated -- we will still serve apps targeting the deprecated version,
   #                  but newly created or updated apps CANNOT target it
   #  * sunsetting -- we will soon be removing support for this version;
-  #                  newly created or updated apps SHOULD target the current version
+  #                  updated apps SHOULD target the current version, no new apps allowed
   #  * current    -- we will serve apps targeting the current version;
   #                  newly created or updated apps SHOULD target it
   #  * future     -- we will serve apps targeting the future version;
@@ -18,6 +18,7 @@ module ZendeskAppsSupport
 
     TO_BE_SERVED     = [DEPRECATED, SUNSETTING, CURRENT, FUTURE].compact.freeze
     VALID_FOR_UPDATE = [SUNSETTING, CURRENT, FUTURE].compact.freeze
+    VALID_FOR_CREATE = [CURRENT, FUTURE].compact.freeze
 
     attr_reader :current
 
@@ -33,6 +34,10 @@ module ZendeskAppsSupport
 
     def valid_for_update?
       VALID_FOR_UPDATE.include?(@version)
+    end
+
+    def valid_for_create?
+      VALID_FOR_CREATE.include?(@version)
     end
 
     def deprecated?

--- a/spec/app_version_spec.rb
+++ b/spec/app_version_spec.rb
@@ -11,6 +11,7 @@ describe ZendeskAppsSupport::AppVersion do
     it { is_expected.to be_present }
     it { is_expected.to be_servable }
     it { is_expected.to be_valid_for_update }
+    it { is_expected.to be_valid_for_create }
     it { is_expected.not_to be_blank }
     it { is_expected.not_to be_deprecated }
     it { is_expected.not_to be_obsolete }
@@ -37,6 +38,7 @@ describe ZendeskAppsSupport::AppVersion do
     it { is_expected.to be_present }
     it { is_expected.to be_servable }
     it { is_expected.not_to be_valid_for_update }
+    it { is_expected.not_to be_valid_for_create }
     it { is_expected.not_to be_blank }
     it { is_expected.to be_deprecated }
     it { is_expected.not_to be_obsolete }
@@ -63,6 +65,7 @@ describe ZendeskAppsSupport::AppVersion do
     it { is_expected.to be_present }
     it { is_expected.not_to be_servable }
     it { is_expected.not_to be_valid_for_update }
+    it { is_expected.not_to be_valid_for_create }
     it { is_expected.not_to be_blank }
     it { is_expected.not_to be_deprecated }
     it { is_expected.to be_obsolete }


### PR DESCRIPTION
@zendesk/wombat @zendesk/vegemite 

### Description
Adding a new validation method to be used in the zendesk_app_market.
Sunsetting will mean updates only and no new apps.

once this gem is bumped, I will update the app market and then write specs for it.

### References
* JIRA: https://zendesk.atlassian.net/browse/APPS-3371

### Risks
low - breaks app updates/create
