### PR TITLE
[AF-776] Check for existence of app name in en.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Zendesk Apps Support
 
 ## Description
-Classes to manage and validate zendesk apps. This is a gem used in [Zendesk Apps Tools](https://github.com/zendesk/zendesk_apps_tools/).
+Classes to manage and validate Zendesk Apps. This is a gem used in [Zendesk Apps Tools](https://github.com/zendesk/zendesk_apps_tools/).
 
 ## Owners
 This repo is owned and maintained by the Zendesk Apps team. You can reach us on vegemite@zendesk.com. We are located in Melbourne!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,6 +92,7 @@ en:
               invalid_format: "%{field} is invalid for translation."
               not_json: "%{file} is not valid JSON. %{errors}"
               not_json_object: "%{file} is not a JSON object."
+              missing_required_key: 'Missing required key from %{file}: %{missing_key}'
             stylesheet_error: 'Sass error: %{sass_error}'
             invalid_type_parameter:
               one: "%{invalid_types} is an invalid parameter type."

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -235,6 +235,10 @@ parts:
       title: "App builder job: translation file is not a JSON object"
       value: "%{file} is not a JSON object."
   - translation:
+      key: "txt.apps.admin.error.app_build.translation.missing_required_key"
+      title: "App builder job: required key missing from translation file"
+      value: "Missing required key from %{file}: %{missing_key}"
+  - translation:
       key: "txt.apps.admin.error.app_build.stylesheet_error"
       title: "App builder job: invalid stylesheet syntax"
       value: "Sass error: %{sass_error}"

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -251,6 +251,7 @@ module ZendeskAppsSupport
 
     def process_translations(locale_path)
       translations = File.exist?(locale_path) ? JSON.parse(File.read(locale_path)) : {}
+      translations['app'].delete('name') if translations.key?('app')
       translations['app'].delete('package') if translations.key?('app')
       remove_zendesk_keys(translations)
     end

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -243,7 +243,7 @@ module ZendeskAppsSupport
     def runtime_translations(translations)
       result = translations.dup
       result.delete('name')
-      result.delete('description')
+      result.delete('short_description')
       result.delete('long_description')
       result.delete('installation_instructions')
       result

--- a/lib/zendesk_apps_support/validations/translations.rb
+++ b/lib/zendesk_apps_support/validations/translations.rb
@@ -17,6 +17,7 @@ module ZendeskAppsSupport
             path_match = TRANSLATIONS_PATH.match(file.relative_path)
             if path_match
               errors << locale_error(file, path_match[1]) << json_error(file)
+              errors << required_keys(file) if errors.compact.empty?
             end
           end.compact
         end
@@ -45,6 +46,14 @@ module ZendeskAppsSupport
           end
         rescue JSON::ParserError => e
           ValidationError.new('translation.not_json', file: file.relative_path, errors: e)
+        end
+
+        def required_keys(file)
+          return if file.relative_path != 'translations/en.json' || JSON.parse(file.read)['app']['name']
+
+          ValidationError.new('translation.missing_required_key',
+                              file: file.relative_path,
+                              missing_key: 'app.name')
         end
 
         def validate_translation_format(json)

--- a/spec/bookmarks_app/translations/en.json
+++ b/spec/bookmarks_app/translations/en.json
@@ -1,6 +1,7 @@
 {
   "app": {
-    "description": "Quickly access bookmarked tickets. Syncs with the iPad app."
+    "name": "Bookmarks App",
+    "short_description": "Quickly access bookmarked tickets. Syncs with the iPad app."
   },
   "custom1": "The first custom thing"
 }

--- a/spec/fixtures/legacy_app_en.js
+++ b/spec/fixtures/legacy_app_en.js
@@ -48,7 +48,7 @@ var app = ZendeskApps.defineApp(source)
       name: "John Smith",
       email: "john@example.com"
     },
-    translations: {"app":{"name":"Buddha Machine"}},
+    translations: {"app":{}},
     templates: {"layout":"<style>\n.app-0 header .logo {\n  background-image: url(\"http://localhost:4567/0/logo-small.png\"); }\n.app-0 h1 {\n  color: red; }\n  .app-0 h1 span {\n    color: green; }\n</style>\n<header>\n  <span class=\"logo\"></span>\n  <h3>{{setting \"name\"}}</h3>\n</header>\n<section data-main></section>\n<footer>\n  <a href=\"mailto:{{author.email}}\">\n    {{author.name}}\n  </a>\n</footer>\n</div>"},
     frameworkVersion: "0.5"
   });

--- a/spec/fixtures/legacy_app_en_experimental_css.js
+++ b/spec/fixtures/legacy_app_en_experimental_css.js
@@ -48,7 +48,7 @@ var app = ZendeskApps.defineApp(source)
       name: "John Smith",
       email: "john@example.com"
     },
-    translations: {"app":{"name":"Buddha Machine"}},
+    translations: {"app":{}},
     templates: {"layout":"<style>\n.app-0 header .logo{background-image:url(\"http://localhost:4567/0/logo-small.png\")}.app-0 h1{color:red}.app-0 h1 span{color:green}\n</style>\n<header>\n  <span class=\"logo\"></span>\n  <h3>{{setting \"name\"}}</h3>\n</header>\n<section data-main></section>\n<footer>\n  <a href=\"mailto:{{author.email}}\">\n    {{author.name}}\n  </a>\n</footer>\n</div>"},
     frameworkVersion: "0.5"
   });

--- a/spec/fixtures/legacy_app_nl.js
+++ b/spec/fixtures/legacy_app_nl.js
@@ -48,7 +48,7 @@ var app = ZendeskApps.defineApp(source)
       name: "John Smith",
       email: "john@example.com"
     },
-    translations: {"app":{"name":"Heilige machine"}},
+    translations: {"app":{}},
     templates: {"layout":"<style>\n.app-1 header .logo {\n  background-image: url(\"http://localhost:4567/2/logo-small.png\"); }\n.app-1 h1 {\n  color: red; }\n  .app-1 h1 span {\n    color: green; }\n</style>\n<header>\n  <span class=\"logo\"></span>\n  <h3>{{setting \"name\"}}</h3>\n</header>\n<section data-main></section>\n<footer>\n  <a href=\"mailto:{{author.email}}\">\n    {{author.name}}\n  </a>\n</footer>\n</div>"},
     frameworkVersion: "0.5"
   });

--- a/spec/fixtures/legacy_app_no_template.js
+++ b/spec/fixtures/legacy_app_no_template.js
@@ -48,7 +48,7 @@ var app = ZendeskApps.defineApp(source)
       name: "John Smith",
       email: "john@example.com"
     },
-    translations: {"app":{"name":"Buddha Machine"}},
+    translations: {"app":{}},
     templates: {"layout":"<style>\n.app-0 header .logo {\n  background-image: url(\"http://localhost:4567/0/logo-small.png\"); }\n.app-0 h1 {\n  color: red; }\n  .app-0 h1 span {\n    color: green; }\n</style>\n<header>\n  <span class=\"logo\"></span>\n  <h3>{{setting \"name\"}}</h3>\n</header>\n<section data-main></section>\n<footer>\n  <a href=\"mailto:{{author.email}}\">\n    {{author.name}}\n  </a>\n</footer>\n</div>"},
     frameworkVersion: "0.5"
   });

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -169,7 +169,7 @@ describe ZendeskAppsSupport::Package do
     let(:custom1) { 'The first custom thing' }
     context 'with default locale' do
       it 'returns translations' do
-        expected_translations = { 'en' => { 'app' => { 'description' => description }, 'custom1' => custom1 } }
+        expected_translations = { 'en' => { 'app' => { 'short_description' => description }, 'custom1' => custom1 } }
         expect(package.send(:translations)).to eq(expected_translations)
         expect(package.locales).to eq(['en'])
       end
@@ -221,7 +221,7 @@ describe ZendeskAppsSupport::Package do
       let(:manifest) { super().merge('defaultLocale' => nil) }
 
       it 'returns translations' do
-        expected_translations = { 'en' => { 'app' => { 'description' => description }, 'custom1' => custom1 } }
+        expected_translations = { 'en' => { 'app' => { 'short_description' => description }, 'custom1' => custom1 } }
         expect(package.send(:translations)).to eq(expected_translations)
         expect(package.locales).to eq(['en'])
       end
@@ -249,7 +249,9 @@ describe ZendeskAppsSupport::Package do
       {
         'app' => {
           'name' => 'Some App',
-          'description' => 'It does something.',
+          'short_description' => 'It does something.',
+          'long_description' => 'Some App does some really fantastic things.',
+          'installation_instructions' => 'Just click install.',
           'everything_else' => 'preserved'
         }
       }
@@ -258,7 +260,7 @@ describe ZendeskAppsSupport::Package do
 
     subject { package.send :runtime_translations, package.translations_for('en').fetch('app') }
 
-    it 'ignores "name" and "description", preserving other keys' do
+    it 'ignores "name", "short_description", "long_description", "installation_instructions", preserving other keys' do
       expect(subject).to eq('everything_else' => 'preserved')
     end
   end

--- a/spec/translations/zh-cn.json
+++ b/spec/translations/zh-cn.json
@@ -1,6 +1,6 @@
 {
   "app": {
-    "description": "从我们的 iPad 和 iPhone app 访问已添加书签的工单"
+    "short_description": "从我们的 iPad 和 iPhone app 访问已添加书签的工单"
   },
   "fetch": {
     "fail": "取回书签时出错",

--- a/spec/translations/zh-cn_keyval.json
+++ b/spec/translations/zh-cn_keyval.json
@@ -1,7 +1,7 @@
 {
   "app": {
     "package": "bookmarks_app",
-    "description": {
+    "short_description": {
       "title": "app description",
       "value": "从我们的 iPad 和 iPhone app 访问已添加书签的工单"
     }

--- a/spec/validations/fixture/invalid_en-US.json
+++ b/spec/validations/fixture/invalid_en-US.json
@@ -1,0 +1,20 @@
+{
+  "app": {
+    "package" : "my_app",
+    "abc" : {
+      "title" : "description for abc field",
+      "value" : "value of abc"
+    }
+  },
+  "a": {
+    "a1": {
+      "title": "description for a1 field",
+      "value": "value of a1"
+    },
+    "b": {
+      "b1": {
+        "value": "value of b1"
+      }
+    }
+  }
+}

--- a/spec/validations/fixture/invalid_en.json
+++ b/spec/validations/fixture/invalid_en.json
@@ -1,20 +1,5 @@
 {
   "app": {
-    "package" : "my_app",
-    "abc" : {
-      "title" : "description for abc field",
-      "value" : "value of abc"
-    }
-  },
-  "a": {
-    "a1": {
-      "title": "description for a1 field",
-      "value": "value of a1"
-    },
-    "b": {
-      "b1": {
-        "value": "value of b1"
-      }
-    }
+    "short_description": "Play some zentunes in your help desk."
   }
 }

--- a/spec/validations/fixture/valid_en-US.json
+++ b/spec/validations/fixture/valid_en-US.json
@@ -1,0 +1,21 @@
+{
+  "app": {
+    "package" : "my_app",
+    "abc" : {
+      "title" : "description for abc field",
+      "value" : "value of abc"
+    }
+  },
+  "a": {
+    "a1": {
+      "title": "description for a1 field",
+      "value": "value of a1"
+    },
+    "b": {
+      "b1": {
+        "title": "description for b1 field",
+        "value": "value of b1"
+      }
+    }
+  }
+}

--- a/spec/validations/fixture/valid_en.json
+++ b/spec/validations/fixture/valid_en.json
@@ -1,21 +1,5 @@
 {
   "app": {
-    "package" : "my_app",
-    "abc" : {
-      "title" : "description for abc field",
-      "value" : "value of abc"
-    }
-  },
-  "a": {
-    "a1": {
-      "title": "description for a1 field",
-      "value": "value of a1"
-    },
-    "b": {
-      "b1": {
-        "title": "description for b1 field",
-        "value": "value of b1"
-      }
-    }
+    "name": "App Name"
   }
 }

--- a/spec/validations/translations_spec.rb
+++ b/spec/validations/translations_spec.rb
@@ -55,6 +55,32 @@ describe ZendeskAppsSupport::Validations::Translations do
     end
   end
 
+  context 'when there is a en.json' do
+    context 'required keys are missing' do
+      let(:translation_files) do
+        [double('AppFile',
+                relative_path: 'translations/en.json',
+                read: read_fixture_file('invalid_en.json'),
+                to_s: 'translations/en.json')]
+      end
+
+      it 'should report the error' do
+        expect(subject.length).to eq(1)
+        expect(subject[0].to_s).to match(/Missing required key from/)
+      end
+    end
+
+    context 'required keys are present' do
+      let(:translation_files) do
+        [double('AppFile', relative_path: 'translations/en.json', read: read_fixture_file('valid_en.json'))]
+      end
+
+      it 'should be valid' do
+        expect(subject.length).to eq(0)
+      end
+    end
+  end
+
   context 'validate translation format when "package" is defined inside "app"' do
     context 'all the leaf nodes have defined "title" and "value"' do
       let(:translation_files) do
@@ -71,7 +97,7 @@ describe ZendeskAppsSupport::Validations::Translations do
         [double('AppFile', relative_path: 'translations/en-US.json', read: read_fixture_file('invalid_en-US.json'))]
       end
 
-      it 'should be invalid' do
+      it 'should report the error' do
         expect(subject.length).to eq(1)
         expect(subject[0].to_s).to match(/is invalid for translation/)
       end

--- a/spec/validations/translations_spec.rb
+++ b/spec/validations/translations_spec.rb
@@ -58,7 +58,7 @@ describe ZendeskAppsSupport::Validations::Translations do
   context 'validate translation format when "package" is defined inside "app"' do
     context 'all the leaf nodes have defined "title" and "value"' do
       let(:translation_files) do
-        [double('AppFile', relative_path: 'translations/en-US.json', read: read_fixture_file('valid_en.json'))]
+        [double('AppFile', relative_path: 'translations/en-US.json', read: read_fixture_file('valid_en-US.json'))]
       end
 
       it 'should be valid' do
@@ -68,7 +68,7 @@ describe ZendeskAppsSupport::Validations::Translations do
 
     context 'when the "title" field is not defined on one leaf node' do
       let(:translation_files) do
-        [double('AppFile', relative_path: 'translations/en-US.json', read: read_fixture_file('invalid_en.json'))]
+        [double('AppFile', relative_path: 'translations/en-US.json', read: read_fixture_file('invalid_en-US.json'))]
       end
 
       it 'should be invalid' do


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Following on from recent changes that require short_description, long_description, and installation_instructions for marketplace apps, en.json is also required to have the app > name property.

```
app {
    name: "This is now required"
}
```

ZAT validation uses ZAS. When running `zat validate` a message is now displayed when a required property is missing.

A [PR to bump ZAT's version of ZAS will be required](https://github.com/zendesk/zendesk_apps_tools/pull/198) once this is merged and tagged.

![image](https://user-images.githubusercontent.com/754567/28552035-41e40b40-712f-11e7-8ad2-c6c546a0907e.png)

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-776

### Risks
* [low] Apps validations will fail