### PR TITLE
[CACT-272] Allow marketing only apps in chat

### DIFF
--- a/lib/zendesk_apps_support/manifest.rb
+++ b/lib/zendesk_apps_support/manifest.rb
@@ -47,8 +47,10 @@ module ZendeskAppsSupport
 
     def products
       @products ||=
-        if requirements_only? || marketing_only?
+        if requirements_only?
           [ Product::SUPPORT ]
+        elsif marketing_only?
+          products_ignore_locations || [ Product::SUPPORT ]
         else
           products_from_locations
         end
@@ -136,6 +138,12 @@ module ZendeskAppsSupport
       location_options.map { |lo| lo.location.product_code }
                       .uniq
                       .map { |code| Product.find_by(code: code) }
+    end
+
+    def products_ignore_locations
+      locations.keys.map do |product_name|
+        Product.find_by(name: product_name)
+      end
     end
 
     def set_locations_and_hosts

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -238,14 +238,31 @@ describe ZendeskAppsSupport::Manifest do
     end
 
     context 'for a marketing only app' do
-      before do
-        manifest_hash.delete(:location)
-        manifest_hash[:marketingOnly] = true
-        manifest_hash[:private] = false
+      context 'when no locations are specified' do
+        before do
+          manifest_hash.delete(:location)
+          manifest_hash[:marketingOnly] = true
+          manifest_hash[:private] = false
+        end
+
+        it 'defaults to Support' do
+          expect(manifest.products).to eq([ ZendeskAppsSupport::Product::SUPPORT ])
+        end
       end
 
-      it 'is overriden to Support' do
-        expect(manifest.products).to eq([ ZendeskAppsSupport::Product::SUPPORT ])
+      context 'when products are specified regardless of locations' do
+        before do
+          manifest_hash[:location][:chat] = {}
+          manifest_hash[:marketingOnly] = true
+          manifest_hash[:private] = false
+        end
+
+        it 'returns the products specified in the manifest' do
+          expect(manifest.products).to eq([
+            ZendeskAppsSupport::Product::SUPPORT,
+            ZendeskAppsSupport::Product::CHAT
+          ])
+        end
       end
     end
   end


### PR DESCRIPTION
:bear:

/cc @zendesk/wombat @zendesk/vegemite 

### Description
Allow marketing only apps to have products and therefore be available for chat.

The products are read from the locations in the manifest and used even if there are no locations specified within the product hash.

If no products are specified it defaults to support to keep it backwards compatible.

### References
* JIRA: https://zendesk.atlassian.net/browse/CACT-272

### Risks
* [low] Breaks marketing only apps