### PR TITLE
[CACT-314] Fix airbrake caused by unsafe hash check

### DIFF
--- a/lib/zendesk_apps_support/validations/translations.rb
+++ b/lib/zendesk_apps_support/validations/translations.rb
@@ -49,7 +49,7 @@ module ZendeskAppsSupport
         end
 
         def required_keys(file)
-          return if file.relative_path != 'translations/en.json' || JSON.parse(file.read)['app']['name']
+          return if file.relative_path != 'translations/en.json' || JSON.parse(file.read).dig('app', 'name')
 
           ValidationError.new('translation.missing_required_key',
                               file: file.relative_path,

--- a/lib/zendesk_apps_support/validations/translations.rb
+++ b/lib/zendesk_apps_support/validations/translations.rb
@@ -49,7 +49,9 @@ module ZendeskAppsSupport
         end
 
         def required_keys(file)
-          return if file.relative_path != 'translations/en.json' || JSON.parse(file.read).dig('app', 'name')
+          return unless file.relative_path == 'translations/en.json'
+          json = JSON.parse(file.read)
+          return if json.is_a?(Hash) && json['app'].is_a?(Hash) && json['app']['name']
 
           ValidationError.new('translation.missing_required_key',
                               file: file.relative_path,


### PR DESCRIPTION
:bear:

/cc @zendesk/wombat @zendesk/vegemite 

### Description
Airbrake was being caused by unsafe hash check when `app` key was not present.
This change makes the check for `app=>name` happen safely.

### Airbrake example
https://zendesk.airbrake.io/projects/105401/groups/2017693197944987628?tab=overview

### Risks
* [low] Doesn't validate presence of app name correctly