### PR TITLE
[CACT-284] Disallow requirements chat-only apps

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,7 +36,7 @@ en:
               an array containing strings
             missing_requirements: Could not find requirements.json
             requirements_not_supported: App requirements are not supported for marketing-only
-              apps
+              apps or Chat-only apps
             manifest_keys:
               missing:
                 one: 'Missing required field in manifest: %{missing_keys}'

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -8,7 +8,7 @@ module ZendeskAppsSupport
         def call(package)
           if package.manifest.requirements_only? && !package.has_requirements?
             return [ValidationError.new(:missing_requirements)]
-          elsif package.manifest.marketing_only? && package.has_requirements?
+          elsif !supports_requirements(package) && package.has_requirements?
             return [ValidationError.new(:requirements_not_supported)]
           elsif !package.has_requirements?
             return []
@@ -34,6 +34,10 @@ module ZendeskAppsSupport
         end
 
         private
+
+        def supports_requirements(package)
+          !package.manifest.marketing_only? && package.manifest.products != [Product::CHAT]
+        end
 
         def missing_required_fields(requirements)
           [].tap do |errors|

--- a/spec/fixtures/chat_only_manifest.json
+++ b/spec/fixtures/chat_only_manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "Chat Only App",
+  "author": {
+    "name": "Chat developer",
+    "email": "support@developer.com",
+    "url": "https://www.google.com/foo/bar-baz"
+  },
+  "defaultLocale": "en",
+  "private": false,
+  "location": {
+    "chat": {
+      "chat_sidebar": "assets/index.html"
+    }
+  },
+  "version": "2.1.1",
+  "frameworkVersion": "2.0"
+}

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -53,6 +53,15 @@ describe ZendeskAppsSupport::Validations::Requirements do
     end
   end
 
+  context 'chat-only app' do
+    let(:manifest) { ZendeskAppsSupport::Manifest.new(File.read('spec/fixtures/chat_only_manifest.json')) }
+    let(:requirements_string) { read_fixture_file('requirements.json') }
+
+    it 'creates an error when the file exists' do
+      expect(errors.first.key).to eq(:requirements_not_supported)
+    end
+  end
+
   context 'there are more than 10 requirements' do
     let(:requirements_string) do
       requirements_content = {}


### PR DESCRIPTION
Chat only apps should not be able to have requirements, since we can't do anything with them in Chat. This PR ensures they fail validation.

https://zendesk.atlassian.net/browse/CACT-284

![screen shot 2017-08-23 at 10 29 32 am](https://user-images.githubusercontent.com/21163718/29593480-ebd3cb20-87ed-11e7-854f-b2d4742ab3d3.png)


Risks:
Low: valid apps are not valid