### PR TITLE
Define new location for chat background

### DIFF
--- a/lib/zendesk_apps_support/location.rb
+++ b/lib/zendesk_apps_support/location.rb
@@ -44,7 +44,8 @@ module ZendeskAppsSupport
                    v2_only: false),
       Location.new(id: 12, orderable: false, name: 'system_top_bar', product_code: Product::SUPPORT.code),
       Location.new(id: 13, orderable: false, name: 'system_top_bar', product_code: Product::STANDALONE_CHAT.code,
-                   v2_only: false)
+                   v2_only: false),
+      Location.new(id: 14, orderable: false, name: 'background', product_code: Product::CHAT.code)
     ].freeze
   end
 end


### PR DESCRIPTION
Defining a new chat background app location. This location is supposed to be a UI less app location and hence is not orderable.

ZAT and ZAM will have to update the gem versions once this is merged and gem version is bumped.

@zendesk/vegemite @zendesk/wombat 