### PR TITLE
[APPS-3536] Only remove name in [translation].json for non-default locale

### DIFF
--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -222,7 +222,7 @@ module ZendeskAppsSupport
         return {} unless File.directory?(translation_dir)
 
         locale_path = "#{translation_dir}/#{manifest.default_locale}.json"
-        default_translations = process_translations(locale_path)
+        default_translations = process_translations(locale_path, default_locale: true)
 
         Dir["#{translation_dir}/*.json"].each_with_object({}) do |path, memo|
           locale = File.basename(path, File.extname(path))
@@ -249,9 +249,9 @@ module ZendeskAppsSupport
       result
     end
 
-    def process_translations(locale_path)
+    def process_translations(locale_path, default_locale: false)
       translations = File.exist?(locale_path) ? JSON.parse(File.read(locale_path)) : {}
-      translations['app'].delete('name') if translations.key?('app')
+      translations['app'].delete('name') if !default_locale && translations.key?('app')
       translations['app'].delete('package') if translations.key?('app')
       remove_zendesk_keys(translations)
     end

--- a/spec/fixtures/legacy_app_en.js
+++ b/spec/fixtures/legacy_app_en.js
@@ -48,7 +48,7 @@ var app = ZendeskApps.defineApp(source)
       name: "John Smith",
       email: "john@example.com"
     },
-    translations: {"app":{}},
+    translations: {"app":{"name":"Buddha Machine"}},
     templates: {"layout":"<style>\n.app-0 header .logo {\n  background-image: url(\"http://localhost:4567/0/logo-small.png\"); }\n.app-0 h1 {\n  color: red; }\n  .app-0 h1 span {\n    color: green; }\n</style>\n<header>\n  <span class=\"logo\"></span>\n  <h3>{{setting \"name\"}}</h3>\n</header>\n<section data-main></section>\n<footer>\n  <a href=\"mailto:{{author.email}}\">\n    {{author.name}}\n  </a>\n</footer>\n</div>"},
     frameworkVersion: "0.5"
   });

--- a/spec/fixtures/legacy_app_en_experimental_css.js
+++ b/spec/fixtures/legacy_app_en_experimental_css.js
@@ -48,7 +48,7 @@ var app = ZendeskApps.defineApp(source)
       name: "John Smith",
       email: "john@example.com"
     },
-    translations: {"app":{}},
+    translations: {"app":{"name":"Buddha Machine"}},
     templates: {"layout":"<style>\n.app-0 header .logo{background-image:url(\"http://localhost:4567/0/logo-small.png\")}.app-0 h1{color:red}.app-0 h1 span{color:green}\n</style>\n<header>\n  <span class=\"logo\"></span>\n  <h3>{{setting \"name\"}}</h3>\n</header>\n<section data-main></section>\n<footer>\n  <a href=\"mailto:{{author.email}}\">\n    {{author.name}}\n  </a>\n</footer>\n</div>"},
     frameworkVersion: "0.5"
   });

--- a/spec/fixtures/legacy_app_nl.js
+++ b/spec/fixtures/legacy_app_nl.js
@@ -48,7 +48,7 @@ var app = ZendeskApps.defineApp(source)
       name: "John Smith",
       email: "john@example.com"
     },
-    translations: {"app":{}},
+    translations: {"app":{"name":"Buddha Machine"}},
     templates: {"layout":"<style>\n.app-1 header .logo {\n  background-image: url(\"http://localhost:4567/2/logo-small.png\"); }\n.app-1 h1 {\n  color: red; }\n  .app-1 h1 span {\n    color: green; }\n</style>\n<header>\n  <span class=\"logo\"></span>\n  <h3>{{setting \"name\"}}</h3>\n</header>\n<section data-main></section>\n<footer>\n  <a href=\"mailto:{{author.email}}\">\n    {{author.name}}\n  </a>\n</footer>\n</div>"},
     frameworkVersion: "0.5"
   });

--- a/spec/fixtures/legacy_app_no_template.js
+++ b/spec/fixtures/legacy_app_no_template.js
@@ -48,7 +48,7 @@ var app = ZendeskApps.defineApp(source)
       name: "John Smith",
       email: "john@example.com"
     },
-    translations: {"app":{}},
+    translations: {"app":{"name":"Buddha Machine"}},
     templates: {"layout":"<style>\n.app-0 header .logo {\n  background-image: url(\"http://localhost:4567/0/logo-small.png\"); }\n.app-0 h1 {\n  color: red; }\n  .app-0 h1 span {\n    color: green; }\n</style>\n<header>\n  <span class=\"logo\"></span>\n  <h3>{{setting \"name\"}}</h3>\n</header>\n<section data-main></section>\n<footer>\n  <a href=\"mailto:{{author.email}}\">\n    {{author.name}}\n  </a>\n</footer>\n</div>"},
     frameworkVersion: "0.5"
   });

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -165,11 +165,20 @@ describe ZendeskAppsSupport::Package do
   end
 
   describe '#translations' do
+    let(:name) { 'Bookmarks App' }
     let(:description) { 'Quickly access bookmarked tickets. Syncs with the iPad app.' }
     let(:custom1) { 'The first custom thing' }
     context 'with default locale' do
       it 'returns translations' do
-        expected_translations = { 'en' => { 'app' => { 'short_description' => description }, 'custom1' => custom1 } }
+        expected_translations = {
+          'en' => {
+            'app' => {
+              'name' => name,
+              'short_description' => description
+            },
+            'custom1' => custom1
+          }
+        }
         expect(package.send(:translations)).to eq(expected_translations)
         expect(package.locales).to eq(['en'])
       end

--- a/spec/translations/zh-cn.json
+++ b/spec/translations/zh-cn.json
@@ -1,5 +1,6 @@
 {
   "app": {
+    "name": "Bookmarks App",
     "short_description": "从我们的 iPad 和 iPhone app 访问已添加书签的工单"
   },
   "fetch": {


### PR DESCRIPTION
:bear:

/cc @zendesk/wombat

### Description
We would like to read app name from `en.json`.

Instead of removing `name` from translations file (e.g. `en.json`) for all locales, we should keep the app name for the default locale.

### References
* JIRA: https://zendesk.atlassian.net/browse/APPS-3536

### Risks
* [low] create translation for unwanted locales