### PR TITLE
[CACT-284] Update the other place translations live in ZAS

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,7 +36,7 @@ en:
               an array containing strings
             missing_requirements: Could not find requirements.json
             requirements_not_supported: App requirements are not supported for marketing-only
-              apps or Chat-only apps
+              or Chat-only apps
             manifest_keys:
               missing:
                 one: 'Missing required field in manifest: %{missing_keys}'

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -79,7 +79,7 @@ parts:
   - translation:
       key: "txt.apps.admin.error.app_build.requirements_not_supported"
       title: "App builder job: requirements not supported error"
-      value: "App requirements are not supported for marketing-only apps"
+      value: "App requirements are not supported for marketing-only or Chat-only apps"
   - translation:
       key: "txt.apps.admin.error.app_build.manifest_keys.missing.one"
       title: "App builder job: missing manifest fields error"


### PR DESCRIPTION
I submitted a previous PR to validate that Chat only apps can't have requirements, but I only updated the error message in `en.yml`. Apparently the error Cactus gets comes from `zendesk_apps_support.yml`, which I didn't catch. This PR updates the other translation.

JIRA: https://zendesk.atlassian.net/browse/CACT-284