### PR TITLE
Fix requirements validations when invalid locations

### DIFF
--- a/lib/zendesk_apps_support/manifest.rb
+++ b/lib/zendesk_apps_support/manifest.rb
@@ -56,6 +56,12 @@ module ZendeskAppsSupport
         end
     end
 
+    def products_ignore_locations
+      locations.keys.map do |product_name|
+        Product.find_by(name: product_name)
+      end
+    end
+
     def location_options
       @location_options ||= locations.flat_map do |product_key, locations|
         product = Product.find_by(name: product_key)
@@ -138,12 +144,6 @@ module ZendeskAppsSupport
       location_options.map { |lo| lo.location.product_code }
                       .uniq
                       .map { |code| Product.find_by(code: code) }
-    end
-
-    def products_ignore_locations
-      locations.keys.map do |product_name|
-        Product.find_by(name: product_name)
-      end
     end
 
     def set_locations_and_hosts

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -36,7 +36,7 @@ module ZendeskAppsSupport
         private
 
         def supports_requirements(package)
-          !package.manifest.marketing_only? && package.manifest.products != [Product::CHAT]
+          !package.manifest.marketing_only? && package.manifest.products_ignore_locations != [Product::CHAT]
         end
 
         def missing_required_fields(requirements)

--- a/spec/fixtures/invalid_location_manifest.json
+++ b/spec/fixtures/invalid_location_manifest.json
@@ -1,0 +1,18 @@
+{
+  "name": "full of errors",
+  "author": {
+    "name": "Po Chen",
+    "email": "po@zendesk.com"
+  },
+  "defaultLocale": "en",
+  "private": true,
+  "location": ["ticket_sidebar", "user_sidebar", "foo_sidebar"],
+  "version": "1.0",
+  "frameworkVersion": "1.0",
+  "parameters": [
+    {
+      "name": "testing_parameters",
+      "type": "wrong"
+    }
+  ]
+}

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -337,6 +337,32 @@ describe ZendeskAppsSupport::Validations::Manifest do
     end
   end
 
+  context 'locations hash is an array of locations in support' do
+    before do
+      allow(@package).to receive(:has_file?).with('assets/iframe.html').and_return(true)
+    end
+
+    describe 'when the locations in the array are valid' do
+      before do
+        @manifest_hash = { 'location' => %w(ticket_sidebar user_sidebar) }
+      end
+
+      it 'should not have an error' do
+        expect(@package).not_to have_error(/invalid location/)
+      end
+    end
+
+    describe 'when there is an invalid location in the array' do
+      before do
+        @manifest_hash = { 'location' => %w(ticket_sidebar user_sidebar invalid_location) }
+      end
+
+      it 'should have an error' do
+        expect(@package).to have_error(/invalid location/)
+      end
+    end
+  end
+
   context 'a v1 app with v2 locations' do
     before do
       @manifest_hash = {

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -183,4 +183,13 @@ describe ZendeskAppsSupport::Validations::Requirements do
       expect(errors.first.data).to eq(field: 'manifest_url', identifier: 'channel_one')
     end
   end
+
+  context 'the locations are invalid' do
+    let(:manifest) { ZendeskAppsSupport::Manifest.new(File.read('spec/fixtures/invalid_location_manifest.json')) }
+    let(:requirements_string) { read_fixture_file('requirements.json') }
+
+    it 'does not return a requirements error' do
+      expect(errors).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
:bear:

/cc @zendesk/wombat @zendesk/vegemite 

### Description
In the requirements validation a call has been added to `manifest.products`, however since this call happens during validation there's no guarantee that the locations are valid and this can error out.

I've replaced this call to use the `products_ignore_locations` method which only looks at the specified products without checking the locations and added some tests for when an array of support locations is used.

### Risks
* [low] Requirements validation issues