### PR TITLE
[APPS-3649] Fix undefined method keys airbrake

### DIFF
--- a/lib/zendesk_apps_support/validations/translations.rb
+++ b/lib/zendesk_apps_support/validations/translations.rb
@@ -64,7 +64,8 @@ module ZendeskAppsSupport
         end
 
         def validate_top_level_required_keys(json, package, file_path)
-          missing_keys = get_missing_keys(package, json['app'].keys)
+          keys = json['app'].is_a?(Hash) ? json['app'].keys : []
+          missing_keys = get_missing_keys(package, keys)
           return if missing_keys.empty?
           ValidationError.new(
             'translation.missing_required_key',

--- a/spec/validations/translations_spec.rb
+++ b/spec/validations/translations_spec.rb
@@ -143,6 +143,16 @@ describe ZendeskAppsSupport::Validations::Translations do
       end
     end
 
+    context 'for an empty translations object' do
+      let(:translation_files) do
+        [double('AppFile', relative_path: 'translations/en.json', read: '{}')]
+      end
+
+      it 'reports missing keys' do
+        expect(subject[0].to_s).to match(%r{Missing required key from translations/en.json})
+      end
+    end
+
     context 'when multiple products are specified' do
       context 'for a public app' do
         let(:private_app?) { false }


### PR DESCRIPTION
We got an airbrake when (I assume) the translations file is an empty hash. This PR fixes it.

https://zendesk.atlassian.net/browse/APPS-3649
https://zendesk.airbrake.io/projects/105401/groups/2049874272888525109?tab=overview&attribute_id=-8115297495119076088&resolved=false