### PR TITLE
[APPS-3651] Stop zas choking on strings that aren't products

### DIFF
--- a/lib/zendesk_apps_support/manifest.rb
+++ b/lib/zendesk_apps_support/manifest.rb
@@ -141,7 +141,7 @@ module ZendeskAppsSupport
     attr_reader :locations
 
     def products_from_locations
-      location_options.map { |lo| lo.location&.product_code }
+      location_options.map { |lo| lo.location && lo.location.product_code }
                       .compact
                       .uniq
                       .map { |code| Product.find_by(code: code) }

--- a/lib/zendesk_apps_support/manifest.rb
+++ b/lib/zendesk_apps_support/manifest.rb
@@ -141,7 +141,8 @@ module ZendeskAppsSupport
     attr_reader :locations
 
     def products_from_locations
-      location_options.map { |lo| lo.location.product_code }
+      location_options.map { |lo| lo.location&.product_code }
+                      .compact
                       .uniq
                       .map { |code| Product.find_by(code: code) }
     end

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -229,7 +229,7 @@ describe ZendeskAppsSupport::Manifest do
     context 'when products is a string that is not a location' do
       before { manifest_hash[:location] = 'cool_location' }
 
-      it 'defaults to support without raising an error' do
+      it 'returns no products without raising an error' do
         expect(manifest.products).to eq([])
       end
     end

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -226,6 +226,22 @@ describe ZendeskAppsSupport::Manifest do
       ])
     end
 
+    context 'when products is a string that is not a location' do
+      before { manifest_hash[:location] = 'cool_location' }
+
+      it 'defaults to support without raising an error' do
+        expect(manifest.products).to eq([])
+      end
+    end
+
+    context 'when products is a string that matches a location' do
+      before { manifest_hash[:location] = 'ticket_sidebar' }
+
+      it 'defaults to support without raising an error' do
+        expect(manifest.products).to eq([ZendeskAppsSupport::Product::SUPPORT])
+      end
+    end
+
     context 'for a requirements only app' do
       before do
         manifest_hash.delete(:location)


### PR DESCRIPTION
Turns out if you specify a location that's just a string, and the string doesn't match a known location name in Support (e.g. "ticket_sidebar"), ZAS will break when it tries to figure out what your products are based on your locations. This PR makes ZAS ignore locations it can't make any sense of.

https://zendesk.airbrake.io/projects/105401/groups/2039767550069022343?tab=notice-detail
https://zendesk.atlassian.net/browse/APPS-3651