### PR TITLE
[APPS-3613] Fix product name capitalization

### DIFF
--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -240,7 +240,7 @@ module ZendeskAppsSupport
             next if invalid_locations.empty?
             errors << ValidationError.new(:invalid_location,
                                           invalid_locations: invalid_locations.join(', '),
-                                          host_name: product.name,
+                                          host_name: product.name.capitalize,
                                           count: invalid_locations.length)
           end
 

--- a/lib/zendesk_apps_support/validations/translations.rb
+++ b/lib/zendesk_apps_support/validations/translations.rb
@@ -80,7 +80,7 @@ module ZendeskAppsSupport
             return ValidationError.new(
               'translation.missing_required_key_for_product',
               file: file_path,
-              product: product,
+              product: product.capitalize,
               missing_key: missing_keys.join(', ')
             )
           end
@@ -93,8 +93,8 @@ module ZendeskAppsSupport
           ValidationError.new(
             'translation.products_do_not_match_manifest_products',
             file: file_path,
-            translation_products: products.join(', '),
-            manifest_products: manifest_products.join(', ')
+            translation_products: products.map(&:capitalize).join(', '),
+            manifest_products: manifest_products.map(&:capitalize).join(', ')
           )
         end
 

--- a/spec/validations/translations_spec.rb
+++ b/spec/validations/translations_spec.rb
@@ -159,7 +159,7 @@ describe ZendeskAppsSupport::Validations::Translations do
           end
 
           it 'should report the error' do
-            expect(subject[0].to_s).to match(%r{Missing required key from translations/en.json for support})
+            expect(subject[0].to_s).to match(%r{Missing required key from translations/en.json for Support})
           end
         end
 
@@ -189,7 +189,7 @@ describe ZendeskAppsSupport::Validations::Translations do
 
             it 'should report the error' do
               expect(subject[0].to_s).to match(
-                /Products in manifest \(support\) do not match products in translations \(support, chat\)/
+                /Products in manifest \(Support\) do not match products in translations \(Support, Chat\)/
               )
             end
           end


### PR DESCRIPTION
/cc @zendesk/wombat
/cc @zendesk/vegemite 

#### Description
Product names (Support, Chat, etc) were not being capitalized in error messages. This PR fixes that issue.

#### References
JIRA: https://zendesk.atlassian.net/browse/APPS-3613

#### Risks
Med: breaks app validation
