### PR TITLE
[APPS-3602] Manifest validation.Return error instead of exploding

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,8 @@ en:
             no_app_js_required: Do not set your app to requirements only if you need
               app.js
             manifest_not_json: manifest is not proper JSON. %{errors}
+            duplicate_manifest_keys: There are duplicate keys specified in the manifest.json
+              file. %{errors}
             missing_manifest: Could not find manifest.json
             nested_manifest: Could not find manifest.json in the root of the zip file,
               but %{found_path} was found. Try re-creating the archive from this directory.

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -45,6 +45,10 @@ parts:
       title: "App builder job: manifest is invalid JSON error"
       value: "manifest is not proper JSON. %{errors}"
   - translation:
+      key: "txt.apps.admin.error.app_build.duplicate_manifest_keys"
+      title: "App builder job: duplicate keys in manifest"
+      value: "There are duplicate keys specified in the manifest.json file. %{errors}"
+  - translation:
       key: "txt.apps.admin.error.app_build.missing_manifest"
       title: "App builder job: missing manifest error"
       value: "Could not find manifest.json"

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -31,7 +31,7 @@ module ZendeskAppsSupport
       [].tap do |errors|
         errors << Validations::Manifest.call(self)
 
-        if has_manifest?
+        if has_manifest? && errors.blank?
           errors << Validations::Marketplace.call(self) if marketplace
           errors << Validations::Source.call(self)
           errors << Validations::Translations.call(self)

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -28,25 +28,24 @@ module ZendeskAppsSupport
     end
 
     def validate(marketplace: true)
-      [].tap do |errors|
-        errors << Validations::Manifest.call(self)
-        if has_manifest? && errors.flatten.empty?
-          errors << Validations::Marketplace.call(self) if marketplace
-          errors << Validations::Source.call(self)
-          errors << Validations::Translations.call(self)
-          errors << Validations::Requirements.call(self)
+      errors = []
+      errors << Validations::Manifest.call(self)
+      if has_valid_manifest?(errors)
+        errors << Validations::Marketplace.call(self) if marketplace
+        errors << Validations::Source.call(self)
+        errors << Validations::Translations.call(self)
+        errors << Validations::Requirements.call(self)
 
-          if !manifest.requirements_only? && !manifest.marketing_only? && !manifest.iframe_only?
-            errors << Validations::Templates.call(self)
-            errors << Validations::Stylesheets.call(self)
-          end
+        unless manifest.requirements_only? || manifest.marketing_only? || manifest.iframe_only?
+          errors << Validations::Templates.call(self)
+          errors << Validations::Stylesheets.call(self)
         end
-
-        errors << Validations::Banner.call(self) if has_banner?
-        errors << Validations::Svg.call(self) if has_svgs?
-
-        errors.flatten!.compact!
       end
+
+      errors << Validations::Banner.call(self) if has_banner?
+      errors << Validations::Svg.call(self) if has_svgs?
+
+      errors.flatten.compact
     end
 
     def validate!(marketplace: true)
@@ -248,6 +247,10 @@ module ZendeskAppsSupport
     end
 
     private
+
+    def has_valid_manifest?(errors)
+      has_manifest? && errors.flatten.empty?
+    end
 
     def runtime_translations(translations)
       result = translations.dup

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -30,8 +30,7 @@ module ZendeskAppsSupport
     def validate(marketplace: true)
       [].tap do |errors|
         errors << Validations::Manifest.call(self)
-
-        if has_manifest? && errors.blank?
+        if has_manifest? && errors.flatten.empty?
           errors << Validations::Marketplace.call(self) if marketplace
           errors << Validations::Source.call(self)
           errors << Validations::Translations.call(self)

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -24,6 +24,8 @@ module ZendeskAppsSupport
 
         rescue JSON::ParserError => e
           return [ValidationError.new(:manifest_not_json, errors: e)]
+        rescue ZendeskAppsSupport::Manifest::OverrideError => e
+          return [ValidationError.new(:duplicate_manifest_keys, errors: e.message)]
         end
 
         private

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -424,7 +424,7 @@ describe ZendeskAppsSupport::Validations::Manifest do
   it 'should have an error when there are duplicate locations' do
     @manifest_hash = { 'location' => %w(ticket_sidebar ticket_sidebar) }
 
-    expect { @package.validate }.to raise_error(/Duplicate reference in manifest: "ticket_sidebar"/)
+    expect(@package).to have_error(/Duplicate reference in manifest: "ticket_sidebar"/)
   end
 
   it 'should have an error when the version is not supported' do


### PR DESCRIPTION
@zendesk/wombat @zendesk/vegemite 

### Description
returns an error which is more user friendly. 
<img width="900" alt="screen shot 2017-10-18 at 5 02 46 pm" src="https://user-images.githubusercontent.com/309246/31703192-3eaa5eb2-b427-11e7-8fe0-fc87bb933999.png">

Prior to this you would see a `something went wrong message` due to an exception thrown at the worker level. 

This also reduces airbrakes.

### Risks
* low - breaks manifest validation