### PR TITLE
Fix path to SVG file for writing sanitised markup

### DIFF
--- a/lib/zendesk_apps_support/validations/svg.rb
+++ b/lib/zendesk_apps_support/validations/svg.rb
@@ -45,15 +45,13 @@ module ZendeskAppsSupport
                                  .scrub!(@empty_malformed_markup)
                                  .to_xml
 
-            filepath = svg.relative_path
-
             next if clean_markup == markup
             begin
               compressed_clean_markup = clean_markup.tr("\n", '').squeeze(' ').gsub(/\>\s+\</, '><')
-              IO.write(filepath, compressed_clean_markup)
-              package.warnings << I18n.t('txt.apps.admin.warning.app_build.sanitised_svg', svg: filepath)
+              IO.write(svg.absolute_path, compressed_clean_markup)
+              package.warnings << I18n.t('txt.apps.admin.warning.app_build.sanitised_svg', svg: svg.relative_path)
             rescue
-              errors << ValidationError.new(:dirty_svg, svg: filepath)
+              errors << ValidationError.new(:dirty_svg, svg: svg.relative_path)
             end
           end
           errors

--- a/spec/validations/svg_spec.rb
+++ b/spec/validations/svg_spec.rb
@@ -2,8 +2,10 @@
 require 'spec_helper'
 
 describe ZendeskAppsSupport::Validations::Svg do
-  let(:svg) { double('AppFile', relative_path: 'assets/icon_nav_bar.svg',
-    absolute_path: '~/tmp/apps/test_app/assets/icon_nav_bar.svg', read: markup) }
+  let(:svg) do
+    double('AppFile', relative_path: 'assets/icon_nav_bar.svg',
+                      absolute_path: '~/tmp/apps/test_app/assets/icon_nav_bar.svg', read: markup)
+  end
   let(:package) { double('Package', svg_files: [svg], warnings: []) }
   let(:warning) do
     'The markup in assets/icon_nav_bar.svg has been edited for use in Zendesk and may not display as intended.'

--- a/spec/validations/svg_spec.rb
+++ b/spec/validations/svg_spec.rb
@@ -2,7 +2,8 @@
 require 'spec_helper'
 
 describe ZendeskAppsSupport::Validations::Svg do
-  let(:svg) { double('AppFile', relative_path: 'assets/icon_nav_bar.svg', read: markup) }
+  let(:svg) { double('AppFile', relative_path: 'assets/icon_nav_bar.svg',
+    absolute_path: '~/tmp/apps/test_app/assets/icon_nav_bar.svg', read: markup) }
   let(:package) { double('Package', svg_files: [svg], warnings: []) }
   let(:warning) do
     'The markup in assets/icon_nav_bar.svg has been edited for use in Zendesk and may not display as intended.'
@@ -115,7 +116,7 @@ stroke="currentColor" stroke-linejoin="round" stroke-width="2" d="M4 8l9-5 9 5v9
       end
       it 'sanitises questionable markup and notifies the user that the offending svgs were modified' do
         errors = ZendeskAppsSupport::Validations::Svg.call(package)
-        expect(IO).to have_received(:write).with(svg.relative_path, clean_markup)
+        expect(IO).to have_received(:write).with(svg.absolute_path, clean_markup)
         expect(package.warnings[0]).to eq(warning)
         expect(errors).to be_empty
       end
@@ -140,7 +141,7 @@ d="M4 8l9-5 9 5v9.7L13 23l-9-5.2zm9 5L4 8m9 5l9-5m-9 5v10"></path></svg onResize
       it 'empties the contents of malformed suspicious svg tags and notifies the user that the offending svgs were \
       modified' do
         errors = ZendeskAppsSupport::Validations::Svg.call(package)
-        expect(IO).to have_received(:write).with(svg.relative_path, empty_svg)
+        expect(IO).to have_received(:write).with(svg.absolute_path, empty_svg)
         expect(package.warnings[0]).to eq(warning)
         expect(errors).to be_empty
       end


### PR DESCRIPTION
:v: 🐨 

/cc @zendesk/vegemite @zendesk/wombat 

### Description
Points to an SVG path that actually exists for the ZAM worker to (re)write to.

### References
* Slack: https://zendesk.slack.com/archives/C122US89L/p1509644506000190

### Risks
* [low] safe SVGs are rewritten and don't display as initially intended