### PR TITLE
Add collapsible attribute to installations

### DIFF
--- a/lib/zendesk_apps_support/installation.rb
+++ b/lib/zendesk_apps_support/installation.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module ZendeskAppsSupport
   class Installation
-    attr_accessor :id, :app_id, :app_name, :requirements, :settings, :enabled, :updated_at, :created_at, :collapsible
+    attr_accessor :id, :app_id, :app_name, :requirements, :settings, :enabled, :collapsible, :updated_at, :created_at
 
     def initialize(options)
       options.each do |k, v|

--- a/lib/zendesk_apps_support/installation.rb
+++ b/lib/zendesk_apps_support/installation.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module ZendeskAppsSupport
   class Installation
-    attr_accessor :id, :app_id, :app_name, :requirements, :settings, :enabled, :updated_at, :created_at
+    attr_accessor :id, :app_id, :app_name, :requirements, :settings, :enabled, :updated_at, :created_at, :collapsible
 
     def initialize(options)
       options.each do |k, v|


### PR DESCRIPTION
Adding a new attribute to the installations class, this is to be used in lotus to check if a particular app instance is collapsible or not.

Required for: https://github.com/zendesk/zendesk_app_market/pull/2888

@zendesk/vegemite 