### PR TITLE
[CACT-354] Validates translation file when parameters are included

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,6 +97,8 @@ en:
               not_json: "%{file} is not valid JSON. %{errors}"
               not_json_object: "%{file} is not a JSON object."
               missing_required_key: 'Missing required key from %{file}: %{missing_key}'
+              missing_required_key_on_leaf: Missing required key %{missing_key} on
+                leaf %{leaf} from %{file}
               missing_required_key_for_product: 'Missing required key from %{file}
                 for %{product}: %{missing_key}'
               products_do_not_match_manifest_products: Products in manifest (%{manifest_products})

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -255,6 +255,11 @@ parts:
       title: "App builder job: required key missing from translation file"
       value: "Missing required key from %{file}: %{missing_key}"
   - translation:
+      key: "txt.apps.admin.error.app_build.translation.missing_required_key_on_leaf"
+      title: "App builder job: required key missing from translation file."
+      screenshot: "https://zendesk.box.com/s/m6yr2j0vai0a7qkimj2gcqiy61jznmn4"
+      value: "Missing required key %{missing_key} on leaf %{leaf} from %{file}"
+  - translation:
       key: "txt.apps.admin.error.app_build.translation.missing_required_key_for_product"
       title: "App builder job: required key missing from translation file for a specific product"
       value: "Missing required key from %{file} for %{product}: %{missing_key}"

--- a/spec/validations/fixture/invalid_pt-br.json
+++ b/spec/validations/fixture/invalid_pt-br.json
@@ -1,0 +1,16 @@
+{
+  "app": {
+    "parameters": {
+      "url": {
+        "label": "URL",
+        "helpText": "The full URL of your account"
+      },
+      "show_photos": {
+        "label": "Show photos",
+        "helpText": "Note: The displayed fields will match the block view configuration"
+      },
+      "description": "this should be invalid, cannot be a string"
+    }
+  },
+  "logout": "Logout"
+}

--- a/spec/validations/fixture/valid_pt-br.json
+++ b/spec/validations/fixture/valid_pt-br.json
@@ -1,0 +1,14 @@
+{
+  "app": {
+    "parameters": {
+      "url": {
+        "label": "URL"
+      },
+      "show_photos": {
+        "label": "Show photos",
+        "helpText": "Note: The displayed fields will match the block view configuration"
+      }
+    }
+  },
+  "logout": "Logout"
+}

--- a/spec/validations/translations_spec.rb
+++ b/spec/validations/translations_spec.rb
@@ -208,6 +208,30 @@ describe ZendeskAppsSupport::Validations::Translations do
     end
   end
 
+  context 'validate translation format when "parameters" is defined inside "app"' do
+    context 'when the leaf nodes do not have a "label"' do
+      let(:translation_files) do
+        [double('AppFile', relative_path: 'translations/pt-br.json', read: read_fixture_file('invalid_pt-br.json'))]
+      end
+
+      it 'should report the error' do
+        expect(subject.length).to eq(1)
+        expect(subject[0].to_s).to \
+          eq('Missing required key label on leaf description from translations/pt-br.json')
+      end
+    end
+
+    context 'when the leaf nodes have "label"' do
+      let(:translation_files) do
+        [double('AppFile', relative_path: 'translations/pt-br.json', read: read_fixture_file('valid_pt-br.json'))]
+      end
+
+      it 'should be valid' do
+        expect(subject.length).to eq(0)
+      end
+    end
+  end
+
   context 'validate translation format when "package" is defined inside "app"' do
     context 'all the leaf nodes have defined "title" and "value"' do
       let(:translation_files) do


### PR DESCRIPTION
🐻 

/cc @zendesk/vegemite @zendesk/wombat 

### Description

 Adds a new validation to each translation file, asserting it has a `label` key on each node under `parameters` . See https://developer.zendesk.com/apps/docs/agent/i18n for example.

### References
* JIRA: https://zendesk.atlassian.net/browse/CACT-354

### Risks
* [low] breaks translation validation