### PR TITLE
don't run translation code for non-v2 apps.

### DIFF
--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -130,7 +130,7 @@ module ZendeskAppsSupport
         location_icons: location_icons,
         app_class_name: app_class_name,
         author: manifest.author,
-        translations: runtime_translations(translations_for(locale)),
+        translations: manifest.iframe_only? ? nil : runtime_translations(translations_for(locale)),
         framework_version: manifest.framework_version,
         templates: templates,
         modules: commonjs_modules,


### PR DESCRIPTION
Easy peasy, lemon skeasy PR for not error when we don't have translations in V2.