### PR TITLE
Valid {{setting.}} url

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,7 @@ en:
             blank_location_uri: "%{location} location does not specify a URI."
             invalid_location_uri: "%{uri} is either an invalid location URI, refers
               to a missing asset, or does not use HTTPS."
+            signed_setting_uri: "%{uri} cannot use a setting because it is signed"
             duplicate_location:
               one: "%{duplicate_locations} is a duplicate location."
               other: "%{duplicate_locations} are duplicate locations."

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -185,6 +185,10 @@ parts:
       title: "App builder job: invalid URI for an iframe in the manifest"
       value: "%{uri} is either an invalid location URI, refers to a missing asset, or does not use HTTPS."
   - translation:
+      key: "txt.apps.admin.error.app_build.signed_setting_uri"
+      title: "App builder job: invalid URI for an iframe in the manifest"
+      value: "%{uri} cannot use a setting because it is signed"
+  - translation:
       key: "txt.apps.admin.error.app_build.duplicate_location.one"
       title: "App builder job: duplicate locations"
       value: "%{duplicate_locations} is a duplicate location."

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -231,7 +231,7 @@ module ZendeskAppsSupport
           errors = []
           package.manifest.location_options.each do |location_options|
             if location_options.url.is_a?(String) && !location_options.url.empty?
-              errors << invalid_location_uri_error(package, location_options.url)
+              errors << invalid_location_uri_error(package, location_options)
             elsif location_options.auto_load?
               errors << ValidationError.new(:blank_location_uri, location: location_options.location.name)
             end
@@ -270,8 +270,12 @@ module ZendeskAppsSupport
           end
         end
 
-        def invalid_location_uri_error(package, path)
+        def invalid_location_uri_error(package, location_options)
+          path = location_options.url
           return nil if path == ZendeskAppsSupport::Manifest::LEGACY_URI_STUB
+          if path.include?('{{setting.')
+            return location_options.signed ? ValidationError.new(:signed_setting_uri) : nil
+          end
           validation_error = ValidationError.new(:invalid_location_uri, uri: path)
           uri = URI.parse(path)
           unless uri.absolute? ? valid_absolute_uri?(uri) : valid_relative_uri?(package, uri)

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -125,6 +125,21 @@ describe ZendeskAppsSupport::Validations::Manifest do
     expect(@package).to have_error(/Missing translation file/)
   end
 
+  it 'should not error when using {{setting.}}' do
+    package = create_package('defaultLocale' => 'en')
+    allow(package.manifest.location_options.first).to receive(:url) { '{{setting.test}}' }
+
+    expect(package).not_to have_error(/%{uri} cannot use a setting because it is signed/)
+  end
+
+  it 'should error when using {{setting.}} with a signed url' do
+    package = create_package('defaultLocale' => 'en')
+    allow(package.manifest.location_options.first).to receive(:url) { '{{setting.test}}' }
+    allow(package.manifest.location_options.first).to receive(:signed) { true }
+
+    expect(package).to have_error(/%{uri} cannot use a setting because it is signed/)
+  end
+
   context 'with a marketing only app' do
     it 'should not have any errors' do
       @package = ZendeskAppsSupport::Package.new('spec/fixtures/marketing_only_app')


### PR DESCRIPTION
/cc @zendesk/vegemite 

If we have a setting we can't check the url for validity, because we don't know how the url is setup.

This will validate any url setting that has a `{{setting.`` in it.
```
url: "{{setting.url}}"
url: "http://{{setting.domain}}.my_server.com/iframe.html"
url: "/assets/{{setting.page}}.html"
```
