### PR TITLE
[LAB] Remove fill attribute from SVG nodes

### DIFF
--- a/lib/zendesk_apps_support/validations/svg.rb
+++ b/lib/zendesk_apps_support/validations/svg.rb
@@ -9,12 +9,12 @@ module ZendeskAppsSupport
 
       # whitelist elements and attributes used in Zendesk Garden assets
       Loofah::HTML5::WhiteList::ALLOWED_ELEMENTS_WITH_LIBXML2.add 'symbol'
-      Loofah::HTML5::WhiteList::ACCEPTABLE_CSS_PROPERTIES.add 'position'
+      Loofah::HTML5::WhiteList::ALLOWED_CSS_PROPERTIES.add 'position'
 
       # CRUFT: ignore a (very specific) style attribute which Loofah would otherwise scrub.
       # This attribute is deprecated (https://www.w3.org/TR/filter-effects/#AccessBackgroundImage)
       # but is included in many of the test apps used in fixtures for tests in ZAM, ZAT etc.
-      Loofah::HTML5::WhiteList::ACCEPTABLE_CSS_PROPERTIES.add 'enable-background'
+      Loofah::HTML5::WhiteList::ALLOWED_CSS_PROPERTIES.add 'enable-background'
 
       @strip_declaration = Loofah::Scrubber.new do |node|
         node.remove if node.name == 'xml' && node.children.empty?

--- a/lib/zendesk_apps_support/validations/svg.rb
+++ b/lib/zendesk_apps_support/validations/svg.rb
@@ -20,6 +20,10 @@ module ZendeskAppsSupport
         node.remove if node.name == 'xml' && node.children.empty?
       end
 
+      @remove_fill_colors = Loofah::Scrubber.new do |node|
+        node.delete('fill') unless node['fill'] == 'none' || node['fill'] == 'currentColor'
+      end
+
       # Loofah's default scrubber strips spaces between CSS attributes. Passing the input markup through this scrubber
       # first ensures that this stripped whitespace in the output doesn't register as a diff.
       @strip_spaces_between_css_attrs = Loofah::Scrubber.new do |node|
@@ -67,6 +71,7 @@ module ZendeskAppsSupport
               clean_markup = Loofah.xml_fragment(markup)
                                    .scrub!(:prune)
                                    .scrub!(@empty_malformed_markup)
+                                   .scrub!(@remove_fill_colors)
                                    .to_xml
 
               next if clean_markup == markup

--- a/spec/validations/svg_spec.rb
+++ b/spec/validations/svg_spec.rb
@@ -173,6 +173,24 @@ with a default placeholder icon.)
     end
   end
 
+  context 'svgs that contain fill colours' do
+    let(:markup) do
+      %(<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 20 20">\
+<circle fill="#78A300" cx="10" cy="10" r="5"/></svg>)
+    end
+    let(:clean_markup) do
+      %(<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 20 20">\
+<circle cx="10" cy="10" r="5"/></svg>)
+    end
+
+    it 'are rewritten without any fill attributes' do
+      errors = subject.call(package)
+      expect(IO).to have_received(:write).with(svg.absolute_path, clean_markup)
+      expect(package.warnings[0]).to eq(warning)
+      expect(errors).to be_empty
+    end
+  end
+
   context 'svgs with questionable markup which are read-only' do
     let(:markup) do
       %(<svg viewBox="0 0 26 26" id="zd-svg-icon-26-app" width="100%" height="100%"><path fill="none" \

--- a/spec/validations/svg_spec.rb
+++ b/spec/validations/svg_spec.rb
@@ -165,7 +165,7 @@ with a default placeholder icon.)
       allow(subject).to receive(:rewrite_svg).and_call_original
     end
 
-    it 'generate a warns the developer, and overwrites the svg with a placeholder image' do
+    it 'generates a warning for the developer, and overwrites the svg with a placeholder image' do
       errors = subject.call(package)
       expect(subject).to have_received(:rewrite_svg).with(svg, subject::PLACEHOLDER_SVG_MARKUP, package, errors)
       expect(package.warnings[0]).to eq(warning)


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite @Eshen 

### Description
As per the developer docs, [SVG icons submitted for a top or nav bar app should not include fill colours](https://developer.zendesk.com/apps/docs/publish/create_assets#dont-include-colors-gradients-shadows-or-bitmaps).

This PR scrubs all instances of the `fill` attribute in SVG nodes, unless the value of it is set to `none` or `currentColor` (currently used throughout default app icons).

### Risks
* Low - regenerates SVGs that include valid attributes.