### PR TITLE
Handle nil framework version

### DIFF
--- a/lib/zendesk_apps_support/manifest.rb
+++ b/lib/zendesk_apps_support/manifest.rb
@@ -103,7 +103,7 @@ module ZendeskAppsSupport
     end
 
     def iframe_only?
-      Gem::Version.new(framework_version) >= Gem::Version.new('2')
+      framework_version && Gem::Version.new(framework_version) >= Gem::Version.new('2')
     end
 
     def parameters

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -384,6 +384,11 @@ describe ZendeskAppsSupport::Manifest do
   end
 
   describe '#iframe_only?' do
+    it 'returns false for an app that has a nil framework version' do
+      manifest_hash[:frameworkVersion] = nil
+      expect(manifest.iframe_only?).to be_falsey
+    end
+
     it 'returns false for an app that has a framework version less than 2' do
       manifest_hash[:frameworkVersion] = '1.0'
       expect(manifest.iframe_only?).to be_falsey


### PR DESCRIPTION
/cc @zendesk/wombat @zendesk/vegemite 

RubyGems v2.7 introduces a change to the `Gem::Version` class which throws an error if an instance is initialised with `nil`. 

https://github.com/rubygems/rubygems/blob/2.7/lib/rubygems/version.rb#L173

Requirements only apps cannot have a specified framework version and were previously having the `iframe_only?` method return `false` but with the latest version of RubyGems this throws an error.