### PR TITLE
[Preview Apps] - skip marketplace translation validation for preview apps

### DIFF
--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -28,13 +28,13 @@ module ZendeskAppsSupport
       @warnings = []
     end
 
-    def validate(marketplace: true)
+    def validate(marketplace: true, skip_marketplace_translations: false)
       errors = []
       errors << Validations::Manifest.call(self)
       if has_valid_manifest?(errors)
         errors << Validations::Marketplace.call(self) if marketplace
         errors << Validations::Source.call(self)
-        errors << Validations::Translations.call(self)
+        errors << Validations::Translations.call(self, skip_marketplace_translations: skip_marketplace_translations)
         errors << Validations::Requirements.call(self)
 
         unless manifest.requirements_only? || manifest.marketing_only? || manifest.iframe_only?
@@ -49,8 +49,8 @@ module ZendeskAppsSupport
       errors.flatten.compact
     end
 
-    def validate!(marketplace: true)
-      errors = validate(marketplace: marketplace)
+    def validate!(marketplace: true, skip_marketplace_translations: false)
+      errors = validate(marketplace: marketplace, skip_marketplace_translations: skip_marketplace_translations)
       raise errors.first if errors.any?
       true
     end

--- a/lib/zendesk_apps_support/validations/translations.rb
+++ b/lib/zendesk_apps_support/validations/translations.rb
@@ -13,13 +13,13 @@ module ZendeskAppsSupport
       end
 
       class << self
-        def call(package)
+        def call(package, opts = {})
           package.files.each_with_object([]) do |file, errors|
             path_match = TRANSLATIONS_PATH.match(file.relative_path)
             next unless path_match
             errors << locale_error(file, path_match[1]) << json_error(file) << format_error(file)
             next unless errors.compact.empty?
-            errors.push(*validate_marketplace_content(file, package)) if file.relative_path == 'translations/en.json'
+            errors.push(*validate_marketplace_content(file, package, opts[:skip_marketplace_translations])) if file.relative_path == 'translations/en.json'
           end.compact
         end
 
@@ -70,24 +70,25 @@ module ZendeskAppsSupport
           ValidationError.new('translation.not_json', file: file.relative_path, errors: e)
         end
 
-        def validate_marketplace_content(file, package)
+        def validate_marketplace_content(file, package, skip_marketplace_translations)
           errors = []
           json = JSON.parse(file.read)
           product_names = Product::PRODUCTS_AVAILABLE.map(&:name)
           present_product_keys = json['app'].is_a?(Hash) ? json['app'].keys & product_names : []
+          skip_marketplace_strings = package.manifest.private? || skip_marketplace_translations
 
           if present_product_keys.empty?
-            errors << validate_top_level_required_keys(json, package, file.relative_path)
+            errors << validate_top_level_required_keys(json, package, file.relative_path, skip_marketplace_strings)
           else
             errors << validate_products_match_manifest_products(present_product_keys, package, file.relative_path)
-            errors << validate_products_have_required_keys(json, package, present_product_keys, file.relative_path)
+            errors << validate_products_have_required_keys(json, package, present_product_keys, file.relative_path, skip_marketplace_strings)
           end
           errors.compact
         end
 
-        def validate_top_level_required_keys(json, package, file_path)
+        def validate_top_level_required_keys(json, package, file_path, skip_marketplace_strings)
           keys = json['app'].is_a?(Hash) ? json['app'].keys : []
-          missing_keys = get_missing_keys(package, keys)
+          missing_keys = get_missing_keys(package, keys, skip_marketplace_strings)
           return if missing_keys.empty?
           ValidationError.new(
             'translation.missing_required_key',
@@ -96,9 +97,9 @@ module ZendeskAppsSupport
           )
         end
 
-        def validate_products_have_required_keys(json, package, products, file_path)
+        def validate_products_have_required_keys(json, package, products, file_path, skip_marketplace_strings)
           products.each do |product|
-            missing_keys = get_missing_keys(package, json['app'][product].keys)
+            missing_keys = get_missing_keys(package, json['app'][product].keys, skip_marketplace_strings)
             next if missing_keys.empty?
             return ValidationError.new(
               'translation.missing_required_key_for_product',
@@ -135,10 +136,9 @@ module ZendeskAppsSupport
           end
         end
 
-        def get_missing_keys(package, keys)
+        def get_missing_keys(package, keys, skip_marketplace_strings)
           public_app_keys = %w[name short_description installation_instructions long_description]
-          mandatory_keys = package.manifest.private? ? ['name'] : public_app_keys
-
+          mandatory_keys = skip_marketplace_strings ? ['name'] : public_app_keys
           # since we support description as well as short_description for backwards compatibility,
           # validate keys as if description == short_description
           keys_to_validate = keys.map do |key|

--- a/lib/zendesk_apps_support/validations/translations.rb
+++ b/lib/zendesk_apps_support/validations/translations.rb
@@ -19,7 +19,10 @@ module ZendeskAppsSupport
             next unless path_match
             errors << locale_error(file, path_match[1]) << json_error(file) << format_error(file)
             next unless errors.compact.empty?
-            errors.push(*validate_marketplace_content(file, package, opts[:skip_marketplace_translations])) if file.relative_path == 'translations/en.json'
+            if file.relative_path == 'translations/en.json'
+              # rubocop:disable Metrics/LineLength
+              errors.push(*validate_marketplace_content(file, package, opts.fetch(:skip_marketplace_translations, false)))
+            end
           end.compact
         end
 
@@ -78,17 +81,22 @@ module ZendeskAppsSupport
           skip_marketplace_strings = package.manifest.private? || skip_marketplace_translations
 
           if present_product_keys.empty?
-            errors << validate_top_level_required_keys(json, package, file.relative_path, skip_marketplace_strings)
+            errors << validate_top_level_required_keys(json, file.relative_path, skip_marketplace_strings)
           else
             errors << validate_products_match_manifest_products(present_product_keys, package, file.relative_path)
-            errors << validate_products_have_required_keys(json, package, present_product_keys, file.relative_path, skip_marketplace_strings)
+            errors << validate_products_have_required_keys(
+              json,
+              present_product_keys,
+              file.relative_path,
+              skip_marketplace_strings
+            )
           end
           errors.compact
         end
 
-        def validate_top_level_required_keys(json, package, file_path, skip_marketplace_strings)
+        def validate_top_level_required_keys(json, file_path, skip_marketplace_strings)
           keys = json['app'].is_a?(Hash) ? json['app'].keys : []
-          missing_keys = get_missing_keys(package, keys, skip_marketplace_strings)
+          missing_keys = get_missing_keys(keys, skip_marketplace_strings)
           return if missing_keys.empty?
           ValidationError.new(
             'translation.missing_required_key',
@@ -97,9 +105,9 @@ module ZendeskAppsSupport
           )
         end
 
-        def validate_products_have_required_keys(json, package, products, file_path, skip_marketplace_strings)
+        def validate_products_have_required_keys(json, products, file_path, skip_marketplace_strings)
           products.each do |product|
-            missing_keys = get_missing_keys(package, json['app'][product].keys, skip_marketplace_strings)
+            missing_keys = get_missing_keys(json['app'][product].keys, skip_marketplace_strings)
             next if missing_keys.empty?
             return ValidationError.new(
               'translation.missing_required_key_for_product',
@@ -136,7 +144,7 @@ module ZendeskAppsSupport
           end
         end
 
-        def get_missing_keys(package, keys, skip_marketplace_strings)
+        def get_missing_keys(keys, skip_marketplace_strings)
           public_app_keys = %w[name short_description installation_instructions long_description]
           mandatory_keys = skip_marketplace_strings ? ['name'] : public_app_keys
           # since we support description as well as short_description for backwards compatibility,

--- a/spec/validations/fixture/name_only_en.json
+++ b/spec/validations/fixture/name_only_en.json
@@ -1,0 +1,5 @@
+{
+  "app": {
+    "name": "App name"
+  }
+}

--- a/spec/validations/translations_spec.rb
+++ b/spec/validations/translations_spec.rb
@@ -42,7 +42,8 @@ describe ZendeskAppsSupport::Validations::Translations do
 
   let(:manifest) { ZendeskAppsSupport::Manifest.new(JSON.dump(manifest_hash)) }
   let(:package) { double('Package', files: translation_files, manifest: manifest) }
-  subject { ZendeskAppsSupport::Validations::Translations.call(package) }
+  let(:opts) { {} }
+  subject { ZendeskAppsSupport::Validations::Translations.call(package, opts) }
 
   context 'when there are no translation files' do
     let(:translation_files) { [] }
@@ -130,6 +131,20 @@ describe ZendeskAppsSupport::Validations::Translations do
         it 'should report the error' do
           expect(subject.length).to eq(1)
           expect(subject[0].to_s).to match(/Missing required key from/)
+        end
+
+        describe 'when the skip_marketplace_translations option is set to true' do
+          let(:translation_files) do
+            [double('AppFile',
+                    relative_path: 'translations/en.json',
+                    read: read_fixture_file('name_only_en.json'),
+                    to_s: 'translations/en.json')]
+          end
+          let(:opts) { {skip_marketplace_translations: true} }
+
+          it 'should be valid' do
+            expect(subject.length).to eq(0)
+          end
         end
       end
 

--- a/spec/validations/translations_spec.rb
+++ b/spec/validations/translations_spec.rb
@@ -140,7 +140,7 @@ describe ZendeskAppsSupport::Validations::Translations do
                     read: read_fixture_file('name_only_en.json'),
                     to_s: 'translations/en.json')]
           end
-          let(:opts) { {skip_marketplace_translations: true} }
+          let(:opts) { { skip_marketplace_translations: true } }
 
           it 'should be valid' do
             expect(subject.length).to eq(0)


### PR DESCRIPTION
@zendesk/wombat 


### Description
Adds a new optional parameter to the validate method, in case you want to skip translations

The PR that skips assets validation is coming in `apps_approval` once this gets merged.