### PR TITLE
Permit and validate custom resource schemas defined in requirements.json

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,9 @@ en:
               other: 'requirements.json contains invalid types: %{invalid_types}'
             multiple_channel_integrations: Specifying multiple channel integrations
               in requirements.json is not supported.
+            invalid_cr_schema_keys:
+              one: 'Custom resources schema contains an invalid key: %{invalid_keys}'
+              other: 'Custom resources schema contains invalid keys: %{invalid_keys}'
             banner:
               invalid_format: Banner image must be a PNG file.
               invalid_size: Invalid banner image dimensions. Must be %{required_banner_width}x%{required_banner_height}px.

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -8,7 +8,7 @@ packages:
 
 parts:
   - translation:
-      key: "txt.apps.admin.error.app_build.jshint.one" 
+      key: "txt.apps.admin.error.app_build.jshint.one"
       title: "App builder job: JSHint error message"
       value: "JSHint error in %{file}: %{errors}"
   - translation:
@@ -119,6 +119,16 @@ parts:
       key: "txt.apps.admin.error.app_build.multiple_channel_integrations"
       title: "App builder job: requirements file contains multiple channel integrations, leave requirements.json as is (file name)"
       value: "Specifying multiple channel integrations in requirements.json is not supported."
+  - translation:
+      key: "txt.apps.admin.error.app_build.invalid_cr_schema_keys.one"
+      title: "App builder job: custom resources schema contains invalid key error"
+      value: "Custom resources schema contains an invalid key: %{invalid_keys}"
+      screenshot: "https://drive.google.com/open?id=1-CHVDcmr5mf1DKKeWqiOuGWrW25gDY4y"
+  - translation:
+      key: "txt.apps.admin.error.app_build.invalid_cr_schema_keys.other"
+      title: "App builder job: custom resources schema contains invalid keys error"
+      value: "Custom resources schema contains invalid keys: %{invalid_keys}"
+      screenshot: "https://drive.google.com/open?id=1iEx7f7PYnum_qDQESD3Gz2PwLDza3zI0"
   - translation:
       key: "txt.apps.admin.error.app_build.banner.invalid_format"
       title: "App builder job: Banner image invalid format error"

--- a/lib/zendesk_apps_support/app_requirement.rb
+++ b/lib/zendesk_apps_support/app_requirement.rb
@@ -2,8 +2,7 @@
 
 module ZendeskAppsSupport
   class AppRequirement
-    TYPES = %w[automations channel_integrations
-               macros targets views ticket_fields triggers
-               user_fields organization_fields].freeze
+    TYPES = %w[automations channel_integrations custom_resources_schema macros targets views ticket_fields
+               triggers user_fields organization_fields].freeze
   end
 end

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -5,7 +5,7 @@ module ZendeskAppsSupport
     module Requirements
       MAX_REQUIREMENTS = 5000
 
-      class <<self
+      class << self
         def call(package)
           if package.manifest.requirements_only? && !package.has_requirements?
             return [ValidationError.new(:missing_requirements)]
@@ -26,6 +26,7 @@ module ZendeskAppsSupport
             errors << excessive_requirements(requirements)
             errors << invalid_channel_integrations(requirements)
             errors << invalid_custom_fields(requirements)
+            errors << invalid_custom_resources_schema(requirements)
             errors << missing_required_fields(requirements)
             errors.flatten!
             errors.compact!
@@ -43,10 +44,12 @@ module ZendeskAppsSupport
         def missing_required_fields(requirements)
           [].tap do |errors|
             requirements.each do |requirement_type, requirement|
-              next if requirement_type == 'channel_integrations'
+              next if %w[channel_integrations custom_resources_schema].include? requirement_type
               requirement.each do |identifier, fields|
                 next if fields.include? 'title'
-                errors << ValidationError.new(:missing_required_fields, field: 'title', identifier: identifier)
+                errors << ValidationError.new(:missing_required_fields,
+                                              field: 'title',
+                                              identifier: identifier)
               end
             end
           end
@@ -65,7 +68,9 @@ module ZendeskAppsSupport
             [user_fields, organization_fields].compact.each do |field_group|
               field_group.each do |identifier, fields|
                 next if fields.include? 'key'
-                errors << ValidationError.new(:missing_required_fields, field: 'key', identifier: identifier)
+                errors << ValidationError.new(:missing_required_fields,
+                                              field: 'key',
+                                              identifier: identifier)
               end
             end
           end
@@ -76,19 +81,40 @@ module ZendeskAppsSupport
           return unless channel_integrations
           [].tap do |errors|
             if channel_integrations.size > 1
-              errors << ValidationError.new(:multiple_channel_integrations, count: channel_integrations.size)
+              errors << ValidationError.new(:multiple_channel_integrations)
             end
             channel_integrations.each do |identifier, fields|
-              unless fields.include? 'manifest_url'
-                errors << ValidationError.new(:missing_required_fields, field: 'manifest_url', identifier: identifier)
-              end
+              next if fields.include? 'manifest_url'
+              errors << ValidationError.new(:missing_required_fields,
+                                            field: 'manifest_url',
+                                            identifier: identifier)
+            end
+          end
+        end
+
+        def invalid_custom_resources_schema(requirements)
+          custom_resources_schema = requirements['custom_resources_schema']
+          return unless custom_resources_schema
+          valid_schema_keys = %w[resource_types relationship_types]
+          [].tap do |errors|
+            invalid_keys = custom_resources_schema.keys - valid_schema_keys
+            unless invalid_keys.empty?
+              errors << ValidationError.new(:invalid_cr_schema_keys,
+                                            invalid_keys: invalid_keys.join(', '),
+                                            count: invalid_keys.length)
+            end
+
+            valid_schema_keys.each do |required_key|
+              next if custom_resources_schema.keys.include? required_key
+              errors << ValidationError.new(:missing_required_fields,
+                                            field: required_key,
+                                            identifier: 'custom_resources_schema')
             end
           end
         end
 
         def invalid_requirements_types(requirements)
           invalid_types = requirements.keys - ZendeskAppsSupport::AppRequirement::TYPES
-
           unless invalid_types.empty?
             ValidationError.new(:invalid_requirements_types,
                                 invalid_types: invalid_types.join(', '),

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -193,4 +193,49 @@ describe ZendeskAppsSupport::Validations::Requirements do
       expect(errors).to be_empty
     end
   end
+
+  context 'there is a valid custom resources schema defined' do
+    let(:requirements_string) do
+      JSON.generate(
+        'custom_resources_schema' => { 'resource_types' => [], 'relationship_types' => [] }
+      )
+    end
+
+    it 'does not return an error' do
+      expect(errors).to be_empty
+    end
+  end
+
+  context 'a custom resources schema contains invalid keys' do
+    let(:requirements_string) do
+      JSON.generate(
+        'custom_resources_schema' => {
+          'resource_types' => [], 'relationship_types' => [], 'resources' => [], 'relationships' => []
+        }
+      )
+    end
+
+    it 'creates an error' do
+      expect(errors.first.key).to eq(:invalid_cr_schema_keys)
+      expect(errors.first.data).to eq(invalid_keys: 'resources, relationships', count: 2)
+    end
+  end
+
+  context 'a custom resources schema is missing resource_types' do
+    let(:requirements_string) { JSON.generate('custom_resources_schema' => { 'relationship_types' => [] }) }
+
+    it 'creates an error' do
+      expect(errors.first.key).to eq(:missing_required_fields)
+      expect(errors.first.data).to eq(field: 'resource_types', identifier: 'custom_resources_schema')
+    end
+  end
+
+  context 'a custom resources schema is missing relationship_types' do
+    let(:requirements_string) { JSON.generate('custom_resources_schema' => { 'resource_types' => [] }) }
+
+    it 'creates an error' do
+      expect(errors.first.key).to eq(:missing_required_fields)
+      expect(errors.first.data).to eq(field: 'relationship_types', identifier: 'custom_resources_schema')
+    end
+  end
 end


### PR DESCRIPTION
Restores https://github.com/zendesk/zendesk_apps_support/pull/212 with syntax fixed for Ruby 2.1