### PR TITLE
[AF-1128] [Patch] Make shallow copy of window instead of deep

### DIFF
--- a/lib/zendesk_apps_support/assets/installed.js.erb
+++ b/lib/zendesk_apps_support/assets/installed.js.erb
@@ -16,7 +16,7 @@
 
   // Adding the wrapped version of jQeury to a clone of window object, which
   // will be used to bind the app's scope.
-  var wrappedWindow = this.$.extend(true, {}, self, { $: wrapped$ });
+  var wrappedWindow = this.$.extend({}, self, { $: wrapped$ });
   wrappedWindow.window = wrappedWindow;
   wrappedWindow.top = wrappedWindow;
 

--- a/lib/zendesk_apps_support/assets/installed.js.erb
+++ b/lib/zendesk_apps_support/assets/installed.js.erb
@@ -1,33 +1,48 @@
 (function() {
-  var self = this;
-  var reporter = window.ZendeskReporter ? new window.ZendeskReporter() : {};
+  <% if apps_zaf_naughty_v1_logging %>
+    var self = this;
+    var reporter = window.ZendeskReporter ? new window.ZendeskReporter() : {};
 
-  // This is just defining a wrapped version of jQuery which simply makes a
-  // pass through call to global window.jQuery and adds logging information
-  // about the origin of the page to Datadog.
-  function wrapped$() {
-    reporter.increment && reporter.increment(
-      'app_framework.app_scope.violated',
-      1,
-      ['origin:' + self.location.hostname]
-    );
-    return self.$.apply(null, arguments);
-  }
+    function getWrappedWindow(appName) {
+      // This is just defining a wrapped version of jQuery which simply makes a
+      // pass through call to global window.jQuery and adds logging information
+      // about the origin of the page to Datadog.
+      function wrapped$() {
+        reporter.increment && reporter.increment(
+          'app_framework.app_scope.violated',
+          1,
+          ['origin:' + self.location.hostname, 'app_name:' + appName]
+        );
 
-  // Adding the wrapped version of jQeury to a clone of window object, which
-  // will be used to bind the app's scope.
-  var wrappedWindow = this.$.extend({}, self, { $: wrapped$ });
-  wrappedWindow.window = wrappedWindow;
-  wrappedWindow.top = wrappedWindow;
+        return self.$.apply(null, arguments);
+      }
+
+      // Adding the wrapped version of jQeury to a clone of window object, which
+      // will be used to bind the app's scope.
+      var wrappedWindow = this.$.extend({}, self, { $: wrapped$ });
+      wrappedWindow.window = wrappedWindow;
+      wrappedWindow.top = wrappedWindow;
+
+      return wrappedWindow;
+    }
+  <% end %>
 
   <% appsjs.each do |appjs| %>
     <% if apps_zaf_naughty_v1_logging %>
+      // Find the appName from source
+      var appName = "UNKNOWN";
+
+      <% appNameMatch = appjs.match(/\.reopen\(\{\s*appName\: (\"[^\n]*\"),/m) %>
+      <% if appNameMatch && appNameMatch.captures.any? %>
+        appName = <%= appNameMatch.captures[0] %>;
+      <% end %>
+
       // Trying to match a v1 apps self executing function here and bind it to the
       // wrappedWindow instance defined above.
       // }()); ==> }.bind(wrappedWindow)());
       <%= appjs.gsub(
         /}\(\)\)\;*\s*;*\s*}\s*var\s*app\s*=\s*ZendeskApps\.defineApp\(source\)/mx,
-        "}.bind(wrappedWindow)());\n;\n}\n\nvar app = ZendeskApps.defineApp(source)"
+        "}.bind(getWrappedWindow(appName))());\n;\n}\n\nvar app = ZendeskApps.defineApp(source)"
       ) %>
     <% else %>
       <%= appjs %>

--- a/spec/fixtures/installed_no_logging.js
+++ b/spec/fixtures/installed_no_logging.js
@@ -16,7 +16,7 @@
 
   // Adding the wrapped version of jQeury to a clone of window object, which
   // will be used to bind the app's scope.
-  var wrappedWindow = this.$.extend(true, {}, self, { $: wrapped$ });
+  var wrappedWindow = this.$.extend({}, self, { $: wrapped$ });
   wrappedWindow.window = wrappedWindow;
   wrappedWindow.top = wrappedWindow;
 

--- a/spec/fixtures/installed_no_logging.js
+++ b/spec/fixtures/installed_no_logging.js
@@ -1,25 +1,4 @@
 (function() {
-  var self = this;
-  var reporter = window.ZendeskReporter ? new window.ZendeskReporter() : {};
-
-  // This is just defining a wrapped version of jQuery which simply makes a
-  // pass through call to global window.jQuery and adds logging information
-  // about the origin of the page to Datadog.
-  function wrapped$() {
-    reporter.increment && reporter.increment(
-      'app_framework.app_scope.violated',
-      1,
-      ['origin:' + self.location.hostname]
-    );
-    return self.$.apply(null, arguments);
-  }
-
-  // Adding the wrapped version of jQeury to a clone of window object, which
-  // will be used to bind the app's scope.
-  var wrappedWindow = this.$.extend({}, self, { $: wrapped$ });
-  wrappedWindow.window = wrappedWindow;
-  wrappedWindow.top = wrappedWindow;
-
   with( ZendeskApps.AppScope.create() ) {
     require.modules = {
         "a.js": function(exports, require, module) {

--- a/spec/fixtures/installed_with_logging.js
+++ b/spec/fixtures/installed_with_logging.js
@@ -16,7 +16,7 @@
 
   // Adding the wrapped version of jQeury to a clone of window object, which
   // will be used to bind the app's scope.
-  var wrappedWindow = this.$.extend(true, {}, self, { $: wrapped$ });
+  var wrappedWindow = this.$.extend({}, self, { $: wrapped$ });
   wrappedWindow.window = wrappedWindow;
   wrappedWindow.top = wrappedWindow;
 

--- a/spec/fixtures/installed_with_logging.js
+++ b/spec/fixtures/installed_with_logging.js
@@ -2,23 +2,33 @@
   var self = this;
   var reporter = window.ZendeskReporter ? new window.ZendeskReporter() : {};
 
-  // This is just defining a wrapped version of jQuery which simply makes a
-  // pass through call to global window.jQuery and adds logging information
-  // about the origin of the page to Datadog.
-  function wrapped$() {
-    reporter.increment && reporter.increment(
-      'app_framework.app_scope.violated',
-      1,
-      ['origin:' + self.location.hostname]
-    );
-    return self.$.apply(null, arguments);
+  function getWrappedWindow(appName) {
+    // This is just defining a wrapped version of jQuery which simply makes a
+    // pass through call to global window.jQuery and adds logging information
+    // about the origin of the page to Datadog.
+    function wrapped$() {
+      reporter.increment && reporter.increment(
+        'app_framework.app_scope.violated',
+        1,
+        ['origin:' + self.location.hostname, 'app_name:' + appName]
+      );
+
+      return self.$.apply(null, arguments);
+    }
+
+    // Adding the wrapped version of jQeury to a clone of window object, which
+    // will be used to bind the app's scope.
+    var wrappedWindow = this.$.extend({}, self, { $: wrapped$ });
+    wrappedWindow.window = wrappedWindow;
+    wrappedWindow.top = wrappedWindow;
+
+    return wrappedWindow;
   }
 
-  // Adding the wrapped version of jQeury to a clone of window object, which
-  // will be used to bind the app's scope.
-  var wrappedWindow = this.$.extend({}, self, { $: wrapped$ });
-  wrappedWindow.window = wrappedWindow;
-  wrappedWindow.top = wrappedWindow;
+  // Find the appName from source
+  var appName = "UNKNOWN";
+
+  appName = "ABC";
 
   // Trying to match a v1 apps self executing function here and bind it to the
   // wrappedWindow instance defined above.
@@ -58,7 +68,7 @@
       }
     };
 
-  }.bind(wrappedWindow)());
+  }.bind(getWrappedWindow(appName))());
   ;
   }
   var app = ZendeskApps.defineApp(source)

--- a/spec/fixtures/installed_with_logging_rollbar.js
+++ b/spec/fixtures/installed_with_logging_rollbar.js
@@ -16,7 +16,7 @@
 
   // Adding the wrapped version of jQeury to a clone of window object, which
   // will be used to bind the app's scope.
-  var wrappedWindow = this.$.extend(true, {}, self, { $: wrapped$ });
+  var wrappedWindow = this.$.extend({}, self, { $: wrapped$ });
   wrappedWindow.window = wrappedWindow;
   wrappedWindow.top = wrappedWindow;
 


### PR DESCRIPTION
Making a shallow copy of window as window object can have references to other iframes, and the browser will not allow us deep copy an iframe from a different origin.

Error in browser without this fix:
![image](https://user-images.githubusercontent.com/17002719/44498801-17ecdd00-a6c4-11e8-88a9-c0fd6c62d4ce.png)

@zendesk/vegemite 