### PR TITLE
No more name, use ID

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ PATH
       json
       loofah (~> 2.2.1)
       nokogiri (~> 1.8.1)
+      rb-inotify (< 0.10.0)
       sass
       sassc (~> 1.11.2)
 
@@ -47,8 +48,8 @@ GEM
       rake
     rake (12.3.0)
     rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)

--- a/lib/zendesk_apps_support/assets/installed.js.erb
+++ b/lib/zendesk_apps_support/assets/installed.js.erb
@@ -4,8 +4,8 @@
   <% end %>
 
   <% installations.each do |installation| %>
-    if (ZendeskApps[<%= installation.app_name.to_json %>]) {
-      ZendeskApps[<%= installation.app_name.to_json %>].install(<%= installation.to_json %>);
+    if (ZendeskApps[<%= installation.app_id.to_json %>]) {
+      ZendeskApps[<%= installation.app_id.to_json %>].install(<%= installation.to_json %>);
     }
   <% end %>
 

--- a/lib/zendesk_apps_support/assets/src.js.erb
+++ b/lib/zendesk_apps_support/assets/src.js.erb
@@ -34,4 +34,4 @@ var app = ZendeskApps.defineApp(<%= iframe_only ? 'null' : 'source' %>)
     frameworkVersion: <%= framework_version.to_json %>
   });
 
-ZendeskApps[<%= name.to_json %>] = app;
+ZendeskApps[<%= id.to_json %>] = app;

--- a/lib/zendesk_apps_support/installed.rb
+++ b/lib/zendesk_apps_support/installed.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'erubis'
+require 'json'
 
 module ZendeskAppsSupport
   class Installed

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -122,6 +122,7 @@ module ZendeskAppsSupport
       templates = manifest.no_template == true ? {} : compiled_templates(app_id, asset_url_prefix)
 
       SRC_TEMPLATE.result(
+        id: app_id,
         name: name,
         version: manifest.version,
         source: source,

--- a/spec/fixtures/iframe_app.js
+++ b/spec/fixtures/iframe_app.js
@@ -14,4 +14,4 @@ var app = ZendeskApps.defineApp(null)
     frameworkVersion: "2.0"
   });
 
-ZendeskApps["ABC"] = app;
+ZendeskApps[0] = app;

--- a/spec/fixtures/installed.js
+++ b/spec/fixtures/installed.js
@@ -57,7 +57,12 @@
 
   ZendeskApps[0] = app;
 
-
+  if (ZendeskApps[0]) {
+    ZendeskApps[0].install({"id":10,"app_id":0,"app_name":"ABC"});
+  }
+  if (ZendeskApps[0]) {
+    ZendeskApps[0].install({"id":20,"app_id":0,"app_name":"EFC"});
+  }
 
 }());
 

--- a/spec/fixtures/installed.js
+++ b/spec/fixtures/installed.js
@@ -55,7 +55,7 @@
       frameworkVersion: "0.5"
     });
 
-  ZendeskApps["ABC"] = app;
+  ZendeskApps[0] = app;
 
 
 

--- a/spec/fixtures/legacy_app_en.js
+++ b/spec/fixtures/legacy_app_en.js
@@ -54,4 +54,4 @@ var app = ZendeskApps.defineApp(source)
     frameworkVersion: "0.5"
   });
 
-ZendeskApps["ABC"] = app;
+ZendeskApps[0] = app;

--- a/spec/fixtures/legacy_app_en_experimental_css.js
+++ b/spec/fixtures/legacy_app_en_experimental_css.js
@@ -54,4 +54,4 @@ var app = ZendeskApps.defineApp(source)
     frameworkVersion: "0.5"
   });
 
-ZendeskApps["ABC"] = app;
+ZendeskApps[0] = app;

--- a/spec/fixtures/legacy_app_nl.js
+++ b/spec/fixtures/legacy_app_nl.js
@@ -54,4 +54,4 @@ var app = ZendeskApps.defineApp(source)
     frameworkVersion: "0.5"
   });
 
-ZendeskApps["EFG"] = app;
+ZendeskApps[1] = app;

--- a/spec/fixtures/legacy_app_no_template.js
+++ b/spec/fixtures/legacy_app_no_template.js
@@ -54,4 +54,4 @@ var app = ZendeskApps.defineApp(source)
     frameworkVersion: "0.5"
   });
 
-ZendeskApps["ABC"] = app;
+ZendeskApps[0] = app;

--- a/spec/fixtures/multi_product_iframe_app.js
+++ b/spec/fixtures/multi_product_iframe_app.js
@@ -14,4 +14,4 @@ var app = ZendeskApps.defineApp(null)
     frameworkVersion: "2.0"
   });
 
-ZendeskApps["ABC"] = app;
+ZendeskApps[0] = app;

--- a/spec/installed_spec.rb
+++ b/spec/installed_spec.rb
@@ -3,12 +3,21 @@
 require 'spec_helper'
 
 describe ZendeskAppsSupport::Installed do
+  let(:installations) { [] }
+
   before do
     appjs = File.read('spec/fixtures/legacy_app_en.js')
-    @installed = ZendeskAppsSupport::Installed.new([appjs])
+    @installed = ZendeskAppsSupport::Installed.new([appjs], installations)
   end
 
   describe 'compile' do
+    let(:installations) do
+      [
+        ZendeskAppsSupport::Installation.new(id: 10, app_id: 0, app_name: 'ABC'),
+        ZendeskAppsSupport::Installation.new(id: 20, app_id: 0, app_name: 'EFC')
+      ]
+    end
+
     it 'should render installed.js' do
       installedjs = @installed.compile(installation_orders: {},
                                        rollbar_zaf_access_token: 'test token')

--- a/zendesk_apps_support.gemspec
+++ b/zendesk_apps_support.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Support to help you develop Zendesk Apps.'
   s.description = s.summary
 
-  s.required_ruby_version = '>= 2.0'
+  s.required_ruby_version = '>= 2.1'
   s.required_rubygems_version = '>= 1.3.6'
 
   s.add_runtime_dependency 'i18n'
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'json'
   s.add_runtime_dependency 'image_size'
   s.add_runtime_dependency 'erubis'
+  s.add_runtime_dependency 'rb-inotify', '< 0.10.0'
   s.add_runtime_dependency 'jshintrb', '~> 0.3.0'
   s.add_runtime_dependency 'loofah', '~> 2.2.1'
   s.add_runtime_dependency 'nokogiri', '~> 1.8.1'


### PR DESCRIPTION
After this being buggy for only 6 years, a fix.

Let's not use **name**, which is not unqiue (anymore), but let's use **id**.

Go by commit for very easy reviewing.

I had to limit `rb-inotify` to under `0.10.0` because Ruby 2.1 is not compatable with `0.10.0`.