### PR TITLE
[AF-1509] Bump loofah and nokogiri to address security vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,8 @@ PATH
       image_size
       jshintrb (~> 0.3.0)
       json
-      loofah (~> 2.2.1)
-      nokogiri (~> 1.8.1)
+      loofah (~> 2.2.3)
+      nokogiri (~> 1.8.5)
       sass
       sassc (~> 1.11.2)
 
@@ -93,4 +93,4 @@ DEPENDENCIES
   zendesk_apps_support!
 
 BUNDLED WITH
-   1.16.2
+   1.16.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,8 +47,8 @@ GEM
       rake
     rake (12.3.0)
     rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)

--- a/zendesk_apps_support.gemspec
+++ b/zendesk_apps_support.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'image_size'
   s.add_runtime_dependency 'erubis'
   s.add_runtime_dependency 'jshintrb', '~> 0.3.0'
-  s.add_runtime_dependency 'loofah', '~> 2.2.1'
-  s.add_runtime_dependency 'nokogiri', '~> 1.8.1'
+  s.add_runtime_dependency 'loofah', '~> 2.2.3'
+  s.add_runtime_dependency 'nokogiri', '~> 1.8.5'
 
   s.add_development_dependency 'rspec', '~> 3.4.0'
   s.add_development_dependency 'bump', '~> 0.5.1'


### PR DESCRIPTION
### Context

A recent github security alerts report mentioned that loofah < 2.2.3 and nokogiri < 1.8.5 have known security vulnerabilities.  Therefore, per the recommendation of this report, bump loofah to 2.2.3 and nokogiri to 1.8.5.

### References

* https://zendesk.atlassian.net/browse/AF-1509
* https://github.com/flavorjones/loofah/compare/v2.2.1...v2.2.3
* https://github.com/sparklemotion/nokogiri/compare/v1.8.1...v1.8.5

### Risks

* (Medium) Breaks app validation in the apps_approval gem, which is used within Cactus (the app developer portal), thereby leading to problems with app submission
* (Low) Breaks app validations in the zendesk_apps_tools gem, thereby leading to issues with the zat command line tool