### PR TITLE
Remove signed setting uri validation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,8 +80,6 @@ en:
             blank_location_uri: "%{location} location does not specify a URI."
             invalid_location_uri: "%{uri} is either an invalid location URI, refers
               to a missing asset, or does not use HTTPS."
-            signed_setting_uri: The url (%{uri}) cannot use a setting because it is
-              a signed url.
             name_as_parameter_name: Can't call a parameter 'name'
             invalid_hidden_parameter:
               one: "%{invalid_params} is set to hidden and cannot be required."

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -194,6 +194,7 @@ parts:
       title: "App builder job: invalid URI for an iframe in the manifest. The `manifest` is a setting file, the `signed url` is https://cloud.google.com/storage/docs/access-control/signed-urls"
       value: "The url (%{uri}) cannot use a setting because it is a signed url."
       screenshot: "https://drive.google.com/open?id=1oQmBeGfNT5EDaEH3oEQoNjaCzBw5XAvL"
+      obsolete: '2019-04-10'
   - translation:
       key: "txt.apps.admin.error.app_build.name_as_parameter_name"
       title: "App builder job: error message when developer names a parameter 'name'"

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -273,6 +273,7 @@ module ZendeskAppsSupport
         def invalid_location_uri_error(package, location_options)
           path = location_options.url
           return nil if path == ZendeskAppsSupport::Manifest::LEGACY_URI_STUB
+          return nil if path.include?('{{setting.')
           validation_error = ValidationError.new(:invalid_location_uri, uri: path)
           uri = URI.parse(path)
           unless uri.absolute? ? valid_absolute_uri?(uri) : valid_relative_uri?(package, uri)

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -273,9 +273,6 @@ module ZendeskAppsSupport
         def invalid_location_uri_error(package, location_options)
           path = location_options.url
           return nil if path == ZendeskAppsSupport::Manifest::LEGACY_URI_STUB
-          if path.include?('{{setting.')
-            return location_options.signed ? ValidationError.new(:signed_setting_uri, uri: path) : nil
-          end
           validation_error = ValidationError.new(:invalid_location_uri, uri: path)
           uri = URI.parse(path)
           unless uri.absolute? ? valid_absolute_uri?(uri) : valid_relative_uri?(package, uri)

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -128,9 +128,11 @@ describe ZendeskAppsSupport::Validations::Manifest do
 
   it 'should not error when using {{setting.}}' do
     package = create_package('defaultLocale' => 'en')
-    allow(package.manifest.location_options.first).to receive(:url) { '{{setting.test}}' }
+    translation_files = double('AppFile', relative_path: 'translations/en.json')
+    allow(@package).to receive_messages(translation_files: [translation_files])
+    allow(package.manifest.location_options.first).to receive(:url) { 'https://zen.{{setting.test}}.com/apps' }
 
-    expect(package).not_to have_error(/the url (.*) cannot use a setting because it is a signed url/)
+    expect(package).not_to have_error
   end
 
   context 'with a marketing only app' do

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -133,14 +133,6 @@ describe ZendeskAppsSupport::Validations::Manifest do
     expect(package).not_to have_error(/the url (.*) cannot use a setting because it is a signed url/)
   end
 
-  it 'should error when using {{setting.}} with a signed url' do
-    package = create_package('defaultLocale' => 'en')
-    allow(package.manifest.location_options.first).to receive(:url) { '{{setting.test}}' }
-    allow(package.manifest.location_options.first).to receive(:signed) { true }
-
-    expect(package).to have_error(/The url (.*) cannot use a setting because it is a signed url/)
-  end
-
   context 'with a marketing only app' do
     it 'should not have any errors' do
       @package = ZendeskAppsSupport::Package.new('spec/fixtures/marketing_only_app')


### PR DESCRIPTION
✌️ @zendesk/vegemite

### Description
Remove validation that restricts `{{setting.yoursettingname}}` usage in signed urls.

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-1208

### Risks
* [Low] removes validation only
