### PR TITLE
Version lock dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,14 @@ PATH
   remote: .
   specs:
     zendesk_apps_support (4.15.0)
-      erubis
-      i18n
-      image_size
+      erubis (~> 2.7.0)
+      i18n (~> 1.5.1)
+      image_size (~> 2.0.0)
       jshintrb (~> 0.3.0)
-      json
+      json (~> 2.2.0)
       loofah (~> 2.2.3)
       nokogiri (~> 1.8.5)
-      sass
+      sass (~> 3.7.4)
       sassc (~> 1.11.2)
 
 GEM
@@ -18,14 +18,16 @@ GEM
     ast (2.4.0)
     bump (0.5.4)
     byebug (9.0.6)
+    concurrent-ruby (1.1.5)
     crass (1.0.4)
     diff-lcs (1.3)
     erubis (2.7.0)
     execjs (2.7.0)
-    faker (1.6.6)
-      i18n (~> 0.5)
+    faker (1.8.7)
+      i18n (>= 0.7)
     ffi (1.9.25)
-    i18n (0.7.0)
+    i18n (1.5.3)
+      concurrent-ruby (~> 1.0)
     image_size (2.0.0)
     jshintrb (0.3.0)
       execjs
@@ -39,13 +41,13 @@ GEM
     multi_json (1.13.1)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
-    parallel (1.12.1)
-    parser (2.5.0.2)
+    parallel (1.17.0)
+    parser (2.6.2.1)
       ast (~> 2.4.0)
-    powerpack (0.1.1)
+    powerpack (0.1.2)
     rainbow (2.2.2)
       rake
-    rake (12.3.0)
+    rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -69,7 +71,7 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.9.0)
+    ruby-progressbar (1.10.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -79,7 +81,7 @@ GEM
       bundler
       ffi (~> 1.9.6)
       sass (>= 3.3.0)
-    unicode-display_width (1.3.0)
+    unicode-display_width (1.5.0)
 
 PLATFORMS
   ruby
@@ -87,7 +89,7 @@ PLATFORMS
 DEPENDENCIES
   bump (~> 0.5.1)
   byebug (~> 9.0.6)
-  faker (~> 1.6.6)
+  faker (~> 1.8.7)
   rspec (~> 3.4.0)
   rubocop (~> 0.49.0)
   zendesk_apps_support!

--- a/zendesk_apps_support.gemspec
+++ b/zendesk_apps_support.gemspec
@@ -13,19 +13,19 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0'
   s.required_rubygems_version = '>= 1.3.6'
 
-  s.add_runtime_dependency 'i18n'
+  s.add_runtime_dependency 'i18n', '~> 1.5.1'
   s.add_runtime_dependency 'sassc', '~> 1.11.2'
-  s.add_runtime_dependency 'sass' # remove explicit dependency when all compilation uses SassC
-  s.add_runtime_dependency 'json'
-  s.add_runtime_dependency 'image_size'
-  s.add_runtime_dependency 'erubis'
+  s.add_runtime_dependency 'sass', '~> 3.7.4' # remove explicit dependency when all compilation uses SassC
+  s.add_runtime_dependency 'json', '~> 2.2.0'
+  s.add_runtime_dependency 'image_size', '~> 2.0.0'
+  s.add_runtime_dependency 'erubis', '~> 2.7.0'
   s.add_runtime_dependency 'jshintrb', '~> 0.3.0'
   s.add_runtime_dependency 'loofah', '~> 2.2.3'
   s.add_runtime_dependency 'nokogiri', '~> 1.8.5'
 
   s.add_development_dependency 'rspec', '~> 3.4.0'
   s.add_development_dependency 'bump', '~> 0.5.1'
-  s.add_development_dependency 'faker', '~> 1.6.6'
+  s.add_development_dependency 'faker', '~> 1.8.7'
   s.add_development_dependency 'rubocop', '~> 0.49.0'
   s.add_development_dependency 'byebug', '~> 9.0.6'
 


### PR DESCRIPTION
✌️ @zendesk/vegemite 

### Summary

Version locking ZAS dependencies to avoid situations like this
https://travis-ci.org/zendesk/zendesk_apps_tools/jobs/517613519

- i18n version number was taken from ZAT
- Faker version number was taken from ZAM, also had to update this to make it work nicely with i18n version 1.5.1
- All others were taken from ZAS Gem.lock