### PR TITLE
Get ZAT working on Windows, Approach 1, Step 1: Only run validation step if app market

### DIFF
--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -44,7 +44,7 @@ module ZendeskAppsSupport
       end
 
       errors << Validations::Banner.call(self) if has_banner?
-      errors << Validations::Svg.call(self) if has_svgs?
+      errors << Validations::Svg.call(self) if marketplace && has_svgs?
 
       errors.flatten.compact
     end


### PR DESCRIPTION
@ocke 's proposed one line change.

We'd also want to have a public unauthenticated endpoint exposed in zendesk_app_market to run this validation.

Furthermore, we'd like zat to consume this endpoint.

Finally, we'd like to launch a security review of the unauthenticated endpoint.

@zendesk/vegemite