### PR TITLE
[MPORT-445] Warn when secrets are detected inside app text files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ PATH
       loofah (~> 2.2.3)
       nokogiri (~> 1.8.5)
       rb-inotify (= 0.9.10)
+      ruby-filemagic
       sass
       sassc (~> 1.11.2)
 
@@ -70,6 +71,7 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-filemagic (0.7.2)
     ruby-progressbar (1.9.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,6 @@ PATH
       loofah (~> 2.2.3)
       nokogiri (~> 1.8.5)
       rb-inotify (= 0.9.10)
-      ruby-filemagic
       sass
       sassc (~> 1.11.2)
 
@@ -28,7 +27,7 @@ GEM
       i18n (~> 0.5)
     ffi (1.9.25)
     i18n (0.7.0)
-    image_size (2.0.0)
+    image_size (2.0.1)
     jshintrb (0.3.0)
       execjs
       multi_json (>= 1.3)
@@ -71,7 +70,6 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-filemagic (0.7.2)
     ruby-progressbar (1.9.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)

--- a/lib/zendesk_apps_support.rb
+++ b/lib/zendesk_apps_support.rb
@@ -21,6 +21,7 @@ module ZendeskAppsSupport
     autoload :ValidationError,       'zendesk_apps_support/validations/validation_error'
     autoload :Manifest,              'zendesk_apps_support/validations/manifest'
     autoload :Marketplace,           'zendesk_apps_support/validations/marketplace'
+    autoload :Secrets,               'zendesk_apps_support/validations/secrets'
     autoload :Source,                'zendesk_apps_support/validations/source'
     autoload :Templates,             'zendesk_apps_support/validations/templates'
     autoload :Translations,          'zendesk_apps_support/validations/translations'

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -31,9 +31,9 @@ module ZendeskAppsSupport
     def validate(marketplace: true, skip_marketplace_translations: false)
       errors = []
       errors << Validations::Manifest.call(self)
+
       if has_valid_manifest?(errors)
         errors << Validations::Marketplace.call(self) if marketplace
-        errors << Validations::Secrets.call(self)
         errors << Validations::Source.call(self)
         errors << Validations::Translations.call(self, skip_marketplace_translations: skip_marketplace_translations)
         errors << Validations::Requirements.call(self)
@@ -46,6 +46,9 @@ module ZendeskAppsSupport
 
       errors << Validations::Banner.call(self) if has_banner?
       errors << Validations::Svg.call(self) if has_svgs?
+
+      # warning only validators
+      Validations::Secrets.call(self)
 
       errors.flatten.compact
     end

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -86,7 +86,7 @@ module ZendeskAppsSupport
     end
 
     def text_files
-      @text_files ||= files.select { |f| f =~ %r{.*((ht|x)ml?|js(on)?)$} } # match .html, .xml, .js and .json
+      @text_files ||= files.select { |f| f =~ %r{.*(html?|xml|js|json?)$} }
     end
 
     def js_files

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -3,7 +3,6 @@
 require 'pathname'
 require 'erubis'
 require 'json'
-require 'filemagic'
 
 module ZendeskAppsSupport
   class Package
@@ -87,7 +86,7 @@ module ZendeskAppsSupport
     end
 
     def text_files
-      files.select { |f| text_file?(f) }
+      @text_files ||= files.select { |f| f =~ %r{.*((ht|x)ml?|js(on)?)$} } # match .html, .xml, .js and .json
     end
 
     def js_files
@@ -370,13 +369,6 @@ module ZendeskAppsSupport
     def read_json(path, parser_opts = {})
       file = read_file(path)
       JSON.parse(read_file(path), parser_opts) unless file.nil?
-    end
-
-    def text_file?(file)
-      fm = FileMagic.new(FileMagic::MAGIC_MIME)
-      fm.file(file.absolute_path) =~ /^text\/|json/
-    ensure
-      fm.close
     end
   end
 end

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -90,7 +90,7 @@ module ZendeskAppsSupport
     end
 
     def js_files
-      @js_files ||= files.select { |f| f.to_s == 'app.js' || (f.to_s.start_with?('lib/') && f.to_s.end_with?('.js')) }
+      @js_files ||= files.select { |f| f =~ %r{^(app|lib\/.*)\.js$} }
     end
 
     def lib_files

--- a/lib/zendesk_apps_support/validations/secrets.rb
+++ b/lib/zendesk_apps_support/validations/secrets.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+
+module ZendeskAppsSupport
+  module Validations
+    module Secrets
+      SECRET_KEYWORDS = %w[
+        pass password secret secretToken secret_token auth_key
+        authKey auth_pass authPass auth_user AuthUser username api_key
+      ].freeze
+
+      class << self
+        def call(package)
+          compromised_files = []
+
+          # Rely on the regexes used by truffleHog (https://github.com/dxa4481/truffleHog) to detect application secrets
+          trufflehog_regexes = JSON.parse(Net::HTTP.get(URI.parse('https://raw.githubusercontent.com/dxa4481/truffleHogRegexes/master/truffleHogRegexes/regexes.json'))).freeze
+
+          package.text_files.each do |file|
+            contents = file.read
+
+            trufflehog_regexes.each do |secret_type, regex_str|
+              next unless contents =~ Regexp.new(regex_str)
+              package.warnings << I18n.t('txt.apps.admin.warning.app_build.application_secret',
+                                         file: file,
+                                         secret_type: secret_type)
+            end
+
+            compromised_files << file.relative_path if contents =~ Regexp.union(SECRET_KEYWORDS)
+          end
+
+          if compromised_files
+            package.warnings << I18n.t('txt.apps.admin.warning.app_build.generic_secrets',
+                                       files: compromised_files.join(', '),
+                                       count: compromised_files.count)
+          end
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/zendesk_apps_support/validations/secrets.rb
+++ b/lib/zendesk_apps_support/validations/secrets.rb
@@ -58,7 +58,7 @@ module ZendeskAppsSupport
             APPLICATION_SECRETS.each do |secret_type, regex_str|
               next unless contents =~ Regexp.new(regex_str)
               package.warnings << I18n.t('txt.apps.admin.warning.app_build.application_secret',
-                                         file: file,
+                                         file: file.relative_path,
                                          secret_type: secret_type)
             end
 
@@ -70,7 +70,7 @@ module ZendeskAppsSupport
                                        files: compromised_files.join(', '),
                                        count: compromised_files.count)
           end
-          nil
+          []
         end
       end
     end

--- a/lib/zendesk_apps_support/validations/secrets.rb
+++ b/lib/zendesk_apps_support/validations/secrets.rb
@@ -65,7 +65,9 @@ module ZendeskAppsSupport
 
           return unless compromised_files.any?
           package.warnings << I18n.t('txt.apps.admin.warning.app_build.generic_secrets',
-                                     files: compromised_files.join(', '),
+                                     files: compromised_files.join(
+                                       I18n.t('txt.apps.admin.error.app_build.listing_comma')
+                                     ),
                                      count: compromised_files.count)
         end
       end

--- a/lib/zendesk_apps_support/validations/secrets.rb
+++ b/lib/zendesk_apps_support/validations/secrets.rb
@@ -50,9 +50,7 @@ module ZendeskAppsSupport
 
       class << self
         def call(package)
-          compromised_files = []
-
-          package.text_files.each do |file|
+          compromised_files = package.text_files.map do |file|
             contents = file.read
 
             APPLICATION_SECRETS.each do |secret_type, regex_str|
@@ -62,8 +60,8 @@ module ZendeskAppsSupport
                                          secret_type: secret_type)
             end
 
-            compromised_files << file.relative_path if contents =~ Regexp.union(SECRET_KEYWORDS)
-          end
+            file.relative_path if contents =~ Regexp.union(SECRET_KEYWORDS)
+          end.compact
 
           if compromised_files.any?
             package.warnings << I18n.t('txt.apps.admin.warning.app_build.generic_secrets',

--- a/lib/zendesk_apps_support/validations/secrets.rb
+++ b/lib/zendesk_apps_support/validations/secrets.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'net/http'
-require 'json'
-
 module ZendeskAppsSupport
   module Validations
     module Secrets
@@ -11,17 +8,54 @@ module ZendeskAppsSupport
         authKey auth_pass authPass auth_user AuthUser username api_key
       ].freeze
 
+      APPLICATION_SECRETS = {
+        # rubocop:disable Metrics/LineLength
+        'Slack Token' => /(xox[p|b|o|a]-*.[a-z0-9])/,
+        'RSA Private Key' => /-----BEGIN RSA PRIVATE KEY-----/,
+        'SSH Private Key (OpenSSH)' => /-----BEGIN OPENSSH PRIVATE KEY-----/,
+        'SSH Private Key (DSA)' => /-----BEGIN DSA PRIVATE KEY-----/,
+        'SSH Private Key (EC)' => /-----BEGIN EC PRIVATE KEY-----/,
+        'PGP Private Key Block' => /-----BEGIN PGP PRIVATE KEY BLOCK-----/,
+        'Facebook OAuth Token' => /([f|F][a|A][c|C][e|E][b|B][o|O][o|O][k|K]( [|:\"=-]|[:\"=-|]).*.[0-9a-f]{24,36})/,
+        'Twitter OAuth Token' => /([t|T][w|W][i|I][t|T][t|T][e|E][r|R]( [:\"=-]|[:\"=-]).*.[0-9a-zA-Z]{30,45})/,
+        'Github Token' => /([g|G][i|I][t|T][h|H][u|U][b|B]( [:\"=-]|[:\"=-]).*.[0-9a-zA-Z]{30,45})/,
+        'Google OAuth Token' => /([c|C][l|L][i|I][e|E][n|N][t|T][\-_][s|S][e|E][c|C][r|R][e|E][t|T]( [:\"=-]|[:\"=-]).*[a-zA-Z0-9\-_]{16,32})/,
+        'AWS Access Key ID' => /(AKIA[0-9A-Z]{8,24})/,
+        'AWS Secret Access Key' => /([a|A][w|W][s|S][_-][s|S][e|E][c|C][r|R][e|E][t|T][_-][a|A][c|C][c|C][e|E][s|S][s|S][_-][k|K][e|E][y|Y].*.[0-9a-zA-Z]{24,48})/,
+        'Heroku API Key' => /([h|H][e|E][r|R][o|O][k|K][u|U].*[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{6,18})/,
+        'Quickpay Secret' => /(quickpay_secret:.*.[0-9a-zA-Z]{24,72})/,
+        'Doorman Secret' => /([d|D][o|O][o|O][r|R][m|M][a|A][n|N][-_][s|S][e|E][c|C][r|R][e|E][t|T].*.[0-9a-f]{16,132})/,
+        'Shared Session Secret' => /(shared_session_secret.*.[0-9a-f]{4,132})/,
+        'Permanent Cookie Secret' => /(permanent_cookie_secret.*.[0-9a-f]{120,156})/,
+        'Scarlett AWS Secret Key' => /([sS][cC][aA][rR][lL][eE][tT][tT][_-][aA][wW][sS][_-][sS][eE][cC][rR][eE][tT][_-][kK][eE][yY].*.[0-9a-zA-Z+.]{35,45})/,
+        'Braintree Key' => /(braintree_key.*.[0-9a-zA-Z]{16,36})/,
+        'Ticket Validation Key' => /(ticket_validation_key.*.[0-9a-zA-Z]{15,25})/,
+        'App Key' => /([aA][pP][pP][-_][kK][eE][yY]( [:\"=-]|[:\"=-]).*.[0-9a-zA-Z+_.-]{4,156})/,
+        'App Secret' => /([aA][pP][pP][-_][sS][eE][cC][rR][eE][tT]( [:\"=-]|[:\"=-]).*.[0-9a-zA-Z+_.-]{4,156})/,
+        'Consumer Key' => /([cC][oO][nN][sS][uU][mM][eE][rR][-_][kK][eE][yY]( [:\"=-]|[:\"=-]).*.[0-9a-zA-Z+_.-]{4,156})/,
+        'Consumer Secret' => /([cC][oO][nN][sS][uU][mM][eE][rR][-_][sS][eE][cC][rR][eE][tT]( [:\"=-]|[:\"=-]).*.[0-9a-zA-Z+_.-]{4,156})/,
+        'Generic Secret' => /(?m)^([sS][eE][cC][rR][eE][tT]( [:\"=-]|[:\"=-]).*.[0-9a-zA-Z+_.-]{4,156})/,
+        'Master Key' => /([mM][aA][sS][tT][eE][rR][-_][kK][eE][yY]( [:\"=-]|[:\"=-]).*.[0-9a-zA-Z+_.-]{4,156})/,
+        'Master Secret' => /([mM][aA][sS][tT][eE][rR][-_][sS][eE][cC][rR][eE][tT]( [:\"=-]|[:\"=-]).*.[0-9a-zA-Z+_.-]{4,156})/,
+        'Token Key' => /([tT][oO][kK][eE][nN][-_][kK][eE][yY]( [:\"=-]|[:\"=-]).*.[0-9a-zA-Z+_.-]{4,156})/,
+        'Token Secret' => /([tT][oO][kK][eE][nN][-_][sS][eE][cC][rR][eE][tT]( [:\"=-]|[:\"=-]).*.[0-9a-zA-Z+_.-]{4,156})/,
+        'Zendesk Zopim Mobile SSO Key' => /(zendesk_zopim_mobile_sso_key.*.[0-9a-f]{58,68})/,
+        'Help Center Private Key' => /([pP][rR][iI][vV][aA][tT][eE][-_][kK][eE][yY]( [:\"=-]|[:\"=-]).*.[0-9a-zA-Z+_.-]{4,156})/,
+        'X-Outbound-Key' => /([xX][-][oO][uU][tT][bB][oO][uU][nN][dD][-][kK][eE][yY][:\" \t=-].*.[0-9a-z-]{32,36})/,
+        'Attachment Token Key' => /(attachment_token_key.*.[0-9a-f]{24,72})/,
+        'Password' => /([pP][aA][sS][sS][wW][oO][rR][dD].*.[0-9a-zA-Z+_.-]{4,156})/,
+        'Token' => /([tT][oO][kK][eE][nN]( [:\"=-]|[:\"=-]).*.[0-9a-zA-Z+_.-]{4,156})/
+        # rubocop:enable Metrics/LineLength
+      }.freeze
+
       class << self
         def call(package)
           compromised_files = []
 
-          # Rely on the regexes used by truffleHog (https://github.com/dxa4481/truffleHog) to detect application secrets
-          trufflehog_regexes = JSON.parse(Net::HTTP.get(URI.parse('https://raw.githubusercontent.com/dxa4481/truffleHogRegexes/master/truffleHogRegexes/regexes.json'))).freeze
-
           package.text_files.each do |file|
             contents = file.read
 
-            trufflehog_regexes.each do |secret_type, regex_str|
+            APPLICATION_SECRETS.each do |secret_type, regex_str|
               next unless contents =~ Regexp.new(regex_str)
               package.warnings << I18n.t('txt.apps.admin.warning.app_build.application_secret',
                                          file: file,
@@ -31,7 +65,7 @@ module ZendeskAppsSupport
             compromised_files << file.relative_path if contents =~ Regexp.union(SECRET_KEYWORDS)
           end
 
-          if compromised_files
+          if compromised_files.any?
             package.warnings << I18n.t('txt.apps.admin.warning.app_build.generic_secrets',
                                        files: compromised_files.join(', '),
                                        count: compromised_files.count)

--- a/lib/zendesk_apps_support/validations/secrets.rb
+++ b/lib/zendesk_apps_support/validations/secrets.rb
@@ -63,12 +63,10 @@ module ZendeskAppsSupport
             file.relative_path if contents =~ Regexp.union(SECRET_KEYWORDS)
           end.compact
 
-          if compromised_files.any?
-            package.warnings << I18n.t('txt.apps.admin.warning.app_build.generic_secrets',
-                                       files: compromised_files.join(', '),
-                                       count: compromised_files.count)
-          end
-          []
+          return unless compromised_files.any?
+          package.warnings << I18n.t('txt.apps.admin.warning.app_build.generic_secrets',
+                                     files: compromised_files.join(', '),
+                                     count: compromised_files.count)
         end
       end
     end

--- a/spec/validations/secrets_spec.rb
+++ b/spec/validations/secrets_spec.rb
@@ -2,12 +2,63 @@
 
 require 'spec_helper'
 
+json_base = '{"name":"App","author":{},"location":{},"version":"1.0"}'
+html_base = '<html><body><script src="zaf_sdk.js"></script></body></html>'
+js_base = 'const client = ZAFClient.init();'
+
 describe ZendeskAppsSupport::Validations::Svg do
-  it 'warns when a generic secret keyword is found' do
-    true
+  let(:mock_json) { json_base }
+  let(:mock_html) { html_base }
+  let(:mock_js) { js_base }
+  let(:subject) { ZendeskAppsSupport::Validations::Secrets }
+  let(:manifest_json) { double('AppFile', relative_path: 'manifest.json', read: mock_json) }
+  let(:iframe_html) { double('AppFile', relative_path: 'assets/iframe.html', read: mock_html) }
+  let(:app_js) { double('AppFile', relative_path: 'assets/app.js', read: mock_js) }
+  let(:files) { [manifest_json, iframe_html, app_js] }
+  let(:package) { double('Package', text_files: files, warnings: []) }
+
+  context 'a single text file containing generic secret keyword(s)' do
+    let(:mock_json) { json_base.gsub('}', '"api_key":"abc123"') }
+    it 'raises an appropriate generic secret warning' do
+      subject.call(package)
+      expect(package.warnings.length).to eq(1)
+      expect(package.warnings[0]).to include('secrets found', 'manifest.json')
+    end
+
+    it 'do not raise any errors' do
+      errors = subject.call(package)
+      expect(errors).to be_empty
+    end
   end
 
-  it 'warns when an application specific secret is found' do
-    true
+  context 'multiple text files containing generic secret keyword(s)' do
+    let(:mock_json) { json_base.gsub('}', '"secret":"abc123"') }
+    let(:mock_html) { html_base.gsub('</script>', '</script><script>const api_key = "abc123"</script>') }
+    it 'raise a single generic grouped warning' do
+      subject.call(package)
+      expect(package.warnings.length).to eq(1)
+      expect(package.warnings[0]).to include('secrets found', 'manifest.json', 'assets/iframe.html')
+    end
+
+    it 'do not raise any errors' do
+      errors = subject.call(package)
+      expect(errors).to be_empty
+    end
+  end
+
+  context 'text files containing application specific secrets or tokens' do
+    let(:mock_json) { json_base.gsub('}', '"github":"d41d8cd98f00b204e9800998ecf8427e"') }
+    let(:mock_js) { js_base.gsub(';', 'const foo = "AKIAIOSFODNN7EXAMPLE";') }
+
+    it 'raise specific warnings for each individual file' do
+      subject.call(package)
+      expect(package.warnings[0]).to include('Github Token found', 'manifest.json')
+      expect(package.warnings[1]).to include('AWS Access Key ID found', 'assets/app.js')
+    end
+
+    it 'do not raise any errors' do
+      errors = subject.call(package)
+      expect(errors).to be_empty
+    end
   end
 end

--- a/spec/validations/secrets_spec.rb
+++ b/spec/validations/secrets_spec.rb
@@ -6,7 +6,7 @@ json_base = '{"name":"App","author":{},"location":{},"version":"1.0"}'
 html_base = '<html><body><script src="zaf_sdk.js"></script></body></html>'
 js_base = 'const client = ZAFClient.init();'
 
-describe ZendeskAppsSupport::Validations::Svg do
+describe ZendeskAppsSupport::Validations::Secrets do
   let(:mock_json) { json_base }
   let(:mock_html) { html_base }
   let(:mock_js) { js_base }

--- a/spec/validations/secrets_spec.rb
+++ b/spec/validations/secrets_spec.rb
@@ -24,11 +24,6 @@ describe ZendeskAppsSupport::Validations::Secrets do
       expect(package.warnings.length).to eq(1)
       expect(package.warnings[0]).to include('secrets found', 'manifest.json')
     end
-
-    it 'do not raise any errors' do
-      errors = subject.call(package)
-      expect(errors).to be_empty
-    end
   end
 
   context 'multiple text files containing generic secret keyword(s)' do
@@ -38,11 +33,6 @@ describe ZendeskAppsSupport::Validations::Secrets do
       subject.call(package)
       expect(package.warnings.length).to eq(1)
       expect(package.warnings[0]).to include('secrets found', 'manifest.json', 'assets/iframe.html')
-    end
-
-    it 'do not raise any errors' do
-      errors = subject.call(package)
-      expect(errors).to be_empty
     end
   end
 
@@ -54,11 +44,6 @@ describe ZendeskAppsSupport::Validations::Secrets do
       subject.call(package)
       expect(package.warnings[0]).to include('Github Token found', 'manifest.json')
       expect(package.warnings[1]).to include('AWS Access Key ID found', 'assets/app.js')
-    end
-
-    it 'do not raise any errors' do
-      errors = subject.call(package)
-      expect(errors).to be_empty
     end
   end
 end

--- a/spec/validations/secrets_spec.rb
+++ b/spec/validations/secrets_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ZendeskAppsSupport::Validations::Svg do
+  it 'warns when a generic secret keyword is found' do
+    true
+  end
+
+  it 'warns when an application specific secret is found' do
+    true
+  end
+end

--- a/zendesk_apps_support.gemspec
+++ b/zendesk_apps_support.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sassc', '~> 1.11.2'
   s.add_runtime_dependency 'sass' # remove explicit dependency when all compilation uses SassC
   s.add_runtime_dependency 'json'
-  s.add_runtime_dependency 'ruby-filemagic'
   s.add_runtime_dependency 'image_size'
   s.add_runtime_dependency 'erubis'
   s.add_runtime_dependency 'jshintrb', '~> 0.3.0'

--- a/zendesk_apps_support.gemspec
+++ b/zendesk_apps_support.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sassc', '~> 1.11.2'
   s.add_runtime_dependency 'sass' # remove explicit dependency when all compilation uses SassC
   s.add_runtime_dependency 'json'
+  s.add_runtime_dependency 'ruby-filemagic'
   s.add_runtime_dependency 'image_size'
   s.add_runtime_dependency 'erubis'
   s.add_runtime_dependency 'jshintrb', '~> 0.3.0'


### PR DESCRIPTION
🐕 

/cc @zendesk/dingo

### Description
Warn developers when the text files submitted in their app packages appear to contain secrets. Uses regexes from [the security checks PoC branch](https://github.com/zendesk/apps_approval/compare/fvilela/kari_security_work) to detect application specific secrets.

Currently these issues are caught as _warnings only_ and don't invalidate the app submission. 

#### Example ZAT output
<a href="https://cl.ly/37cea0ef143c" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/2B0l3w2k3L3r1X1q2S2L/Image%202019-05-16%20at%204.19.33%20pm.png" style="display: block;height: auto;width: 100%;"/></a>

### References
* JIRA: https://zendesk.atlassian.net/browse/MPORT-445
* Translations: https://github.com/zendesk/zendesk_apps_support/pull/227

### Risks
* Low - causes alarm/confusion with developers previously unaware of exposed secrets in their code.