### PR TITLE
[MPORT-442] Create Strings for MIME type ValidationError

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,9 @@ en:
             invalid_requirements_types:
               one: 'requirements.json contains an invalid type: %{invalid_types}'
               other: 'requirements.json contains invalid types: %{invalid_types}'
+            unsupported_mime_type_detected:
+              one: 'Unsupported MIME type detected in %{file_names}'
+              other: 'Unsupported MIME types detected in %{file_names}'
             multiple_channel_integrations: Specifying multiple channel integrations
               in requirements.json is not supported.
             invalid_cr_schema_keys:

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -120,6 +120,16 @@ parts:
       title: "App builder job: requirements file contains invalid types error"
       value: "requirements.json contains invalid types: %{invalid_types}"
   - translation:
+      key: "txt.apps.admin.error.app_build.unsupported_mime_type_detected.one"
+      title: "App builder job: directory contains unsupported mime type. MIME is an abbreviation for Multipurpose Internet Mail Extensions. https://en.wikipedia.org/wiki/MIME"
+      value: "Unsupported MIME type detected in %{file_names}."
+      screenshot: "https://drive.google.com/open?id=13sG5kRWrcVPZiFzDLYo-WavY4WbsHdvX"
+  - translation:
+      key: "txt.apps.admin.error.app_build.unsupported_mime_type_detected.other"
+      title: "App builder job: directory contains unsupported mime type. MIME is an abbreviation for Multipurpose Internet Mail Extensions. https://en.wikipedia.org/wiki/MIME"
+      value: "Unsupported MIME types detected in %{file_names}."
+      screenshot: "https://drive.google.com/open?id=1Ht4Nq4ZcQ0DMfcm6JphF66QI3e1FT8Wn"
+  - translation:
       key: "txt.apps.admin.error.app_build.multiple_channel_integrations"
       title: "App builder job: requirements file contains multiple channel integrations, leave requirements.json as is (file name)"
       value: "Specifying multiple channel integrations in requirements.json is not supported."


### PR DESCRIPTION
@zendesk/dingo @zendesk/wattle-dev @zendesk/localization

## Descriptions:
Localization for [this](https://github.com/zendesk/zendesk_apps_support/pull/228).

## Screenshots:
<details>
<summary>app without unsupported mime type files</summary>
<img src="https://user-images.githubusercontent.com/17760485/59315255-55c2fc80-8cfc-11e9-8ba5-643bde1ce955.png">
</details>

<details>
<summary>app with unsupported mime type files</summary>

<img src='https://user-images.githubusercontent.com/17760485/59396495-6478e480-8dcc-11e9-8bf0-8895adeada6e.png'>

<img src='https://user-images.githubusercontent.com/17760485/59396496-65117b00-8dcc-11e9-8cf7-645f926bfa06.png'>
</details>

## References:
- [JIRA](https://zendesk.atlassian.net/browse/MPORT-442)

## Risks:
- Low, strings only