### PR TITLE
[MPORT-443] Add validations for insecure and block-listed requests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       erubis
       i18n
       image_size
+      ipaddress_2 (~> 0.13.0)
       json
       loofah (~> 2.2.3)
       mimemagic (~> 0.3.3)
@@ -27,6 +28,7 @@ GEM
     ffi (1.9.25)
     i18n (0.7.0)
     image_size (2.0.1)
+    ipaddress_2 (0.13.0)
     json (2.2.0)
     loofah (2.2.3)
       crass (~> 1.0.2)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,8 +54,8 @@ en:
               one: 'requirements.json contains an invalid type: %{invalid_types}'
               other: 'requirements.json contains invalid types: %{invalid_types}'
             unsupported_mime_type_detected:
-              one: 'Unsupported MIME type detected in %{file_names}'
-              other: 'Unsupported MIME types detected in %{file_names}'
+              one: Unsupported MIME type detected in %{file_names}.
+              other: Unsupported MIME types detected in %{file_names}.
             multiple_channel_integrations: Specifying multiple channel integrations
               in requirements.json is not supported.
             invalid_cr_schema_keys:
@@ -144,6 +144,6 @@ en:
               other: Possible secrets found in %{files}. Consider reviewing the contents
                 of these files before submitting your app.
             insecure_http_request: Possible insecure HTTP request to %{uri} in %{file}.
-              Consider instead using the HTTPS protocol.
+              Consider using the HTTPS protocol instead.
             application_secret: Possible %{secret_type} found in %{file}. Consider
               reviewing the contents of this file before submitting your app.

--- a/lib/zendesk_apps_support.rb
+++ b/lib/zendesk_apps_support.rb
@@ -28,6 +28,7 @@ module ZendeskAppsSupport
     autoload :Translations,          'zendesk_apps_support/validations/translations'
     autoload :Stylesheets,           'zendesk_apps_support/validations/stylesheets'
     autoload :Requirements,          'zendesk_apps_support/validations/requirements'
+    autoload :Requests,              'zendesk_apps_support/validations/requests'
     autoload :Banner,                'zendesk_apps_support/validations/banner'
     autoload :Svg,                   'zendesk_apps_support/validations/svg'
   end

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -37,6 +37,7 @@ module ZendeskAppsSupport
         errors << Validations::Source.call(self)
         errors << Validations::Translations.call(self, skip_marketplace_translations: skip_marketplace_translations)
         errors << Validations::Requirements.call(self)
+        errors << Validations::Requests.call(self)
 
         unless manifest.requirements_only? || manifest.marketing_only? || manifest.iframe_only?
           errors << Validations::Templates.call(self)
@@ -95,6 +96,10 @@ module ZendeskAppsSupport
 
     def js_files
       @js_files ||= files.select { |f| f =~ %r{^.*\.jsx?$} }
+    end
+
+    def html_files
+      @html_files ||= files.select { |f| f =~ %r{.*\.html?$} }
     end
 
     def lib_files

--- a/lib/zendesk_apps_support/validations/requests.rb
+++ b/lib/zendesk_apps_support/validations/requests.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'uri'
+require 'ipaddress_2'
+
+module ZendeskAppsSupport
+  module Validations
+    module Requests
+      class << self
+        HTTP_REQUEST_METHODS = %w[GET HEAD POST PUT DELETE CONNECT OPTIONS TRACE].freeze
+
+        REQUEST_CALLS = [
+          /\w+\.request\(['"](.*)['"]/i, # ZAF request
+          /(?:\$|jQuery)\.(?:ajax|get|post|getJSON)\(['"](.*)['"]/i, # jQuery request
+          /\w+\.open\(['"](?:#{Regexp.union(HTTP_REQUEST_METHODS).source})['"],\s?['"](.*)['"]/i, # XMLHttpRequest
+          /fetch\(['"](.*)['"]/i # fetch
+        ].freeze
+
+        def call(package)
+          errors = []
+          files = package.js_files + package.html_files
+
+          files.each do |file|
+            contents = file.read
+            REQUEST_CALLS.each do |request_pattern|
+              request = contents.match(request_pattern)
+              next unless request
+              uri = URI(request.captures[0])
+              if uri.scheme == 'http'
+                package.warnings << I18n.t('txt.apps.admin.warning.app_build.insecure_http_request',
+                                           uri: uri,
+                                           file: file.relative_path)
+              end
+
+              next unless IPAddress.valid? uri.host
+              ip = IPAddress.parse uri.host
+
+              blocked_ip_type = if ip.private?
+                                  I18n.t('txt.apps.admin.error.app_build.blocked_request_private')
+                                elsif ip.loopback?
+                                  I18n.t('txt.apps.admin.error.app_build.blocked_request_loopback')
+                                elsif ip.link_local?
+                                  I18n.t('txt.apps.admin.error.app_build.blocked_request_link_local')
+                                end
+
+              next unless blocked_ip_type
+              errors << I18n.t('txt.apps.admin.error.app_build.blocked_request',
+                               type: blocked_ip_type,
+                               uri: uri.host,
+                               file: file.relative_path)
+            end
+          end
+          errors
+        end
+      end
+    end
+  end
+end

--- a/spec/validations/requests_spec.rb
+++ b/spec/validations/requests_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+def request_function(style, address)
+  case style
+  when 'ZAF'
+    "function request() { client.request('#{address}') }"
+  when 'jQuery'
+    "function request() { jQuery.get('#{address}') }"
+  when 'jQuery$'
+    "function request() { $.ajax('#{address}') }"
+  when 'XMLHttpRequest'
+    "function request() { xhr.open('get', '#{address}') }"
+  when 'fetch'
+    "function request() { fetch('#{address}') }"
+  end
+end
+
+request_function_styles = %w[ZAF jQuery jQuery$ XMLHttpRequest fetch]
+
+shared_examples 'an insecure request' do |file_path, function_style|
+  address = 'http://foo.com'
+  let(:markup) { request_function(function_style, address) }
+
+  it "and raise a warning inside #{function_style} style requests" do
+    errors = subject.call(package)
+    expect(package.warnings[0]).to include('insecure HTTP request', address, file_path)
+    expect(errors).to be_empty
+  end
+end
+
+blocked_ips = {
+  private: {
+    range: '10.0.0.0/8, 172.16.0.0/12, or 192.168.0.0/16',
+    example: '192.168.0.1'
+  },
+  loopback: {
+    range: '127.0.0.0/8',
+    example: '127.0.0.1'
+  },
+  link_local: {
+    range: '169.254.0.0/16',
+    example: '169.254.0.1'
+  }
+}
+
+shared_examples 'a blocked ip' do |file_path, function_style, ip_type, ip|
+  let(:markup) { request_function(function_style, "https://#{ip}") }
+
+  it "and throw a #{ip_type} ip error inside #{function_style} style request calls" do
+    errors = subject.call(package)
+    expect(package.warnings).to be_empty
+    expect(errors[0]).to include("request to a #{ip_type} ip", ip, file_path)
+  end
+end
+
+describe ZendeskAppsSupport::Validations::Requests do
+  app_js_path = 'assets/app.js'
+  let(:app_js) { double('AppFile', relative_path: app_js_path, read: markup) }
+  let(:subject) { ZendeskAppsSupport::Validations::Requests }
+  let(:package) { double('Package', js_files: [app_js], html_files: [], warnings: []) }
+
+  describe 'using the http protocol' do
+    request_function_styles.each { |function_style| it_behaves_like 'an insecure request', app_js_path, function_style }
+  end
+
+  blocked_ips.each do |type, ip|
+    describe "to #{ip[:range]} range ips" do
+      request_function_styles.each do |function_style|
+        type_localised = ZendeskAppsSupport::I18n.t("txt.apps.admin.error.app_build.blocked_request_#{type}")
+        it_behaves_like 'a blocked ip', app_js_path, function_style, type_localised, ip[:example]
+      end
+    end
+  end
+end

--- a/zendesk_apps_support.gemspec
+++ b/zendesk_apps_support.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'nokogiri', '~> 1.8.5'
   s.add_runtime_dependency 'rb-inotify', '0.9.10'
   s.add_runtime_dependency 'mimemagic', '~> 0.3.3'
-
+  s.add_runtime_dependency 'ipaddress_2', '~> 0.13.0'
   s.add_development_dependency 'rspec', '~> 3.4.0'
   s.add_development_dependency 'bump', '~> 0.5.1'
   s.add_development_dependency 'faker', '~> 1.6.6'


### PR DESCRIPTION
🐕 

/cc @zendesk/dingo

### Description
1. Scan JS and HTML files for common Javascript request function call patterns (i.e. jQuery, XMLHttpRequest, fetch, and Zendesk App Framework `.request` calls)
1. **Error** if calls are being made to:
	1. RFC1918 **private** network addresses (10.0.0.0/8, 172.16.0.0/12, or 192.168.0.0/16 range)
	1. RFC1122 **loopback** network addresses (127.0.0.0/8 range)
	1. RFC3927 **link-local** network addresses (169.254.0.0/16 range)
1. **Warn** if requests are made via `http` instead of `https`.

Uses the [IPAddress gem](https://github.com/ipaddress-gem/ipaddress) to validate IPs and address types.

### References
* JIRA: https://zendesk.atlassian.net/browse/MPORT-443
* Translations: https://github.com/zendesk/zendesk_apps_support/pull/231

### Risks
* Medium - causes apps with legitimate requests to be rejected.