### PR TITLE
[MPORT-501] Include secure settings check in validations

### DIFF
--- a/lib/zendesk_apps_support.rb
+++ b/lib/zendesk_apps_support.rb
@@ -20,6 +20,7 @@ module ZendeskAppsSupport
   module Validations
     autoload :ValidationError,       'zendesk_apps_support/validations/validation_error'
     autoload :Manifest,              'zendesk_apps_support/validations/manifest'
+    autoload :SecureSettings,        'zendesk_apps_support/validations/secure_settings'
     autoload :Marketplace,           'zendesk_apps_support/validations/marketplace'
     autoload :Mime,                  'zendesk_apps_support/validations/mime'
     autoload :Secrets,               'zendesk_apps_support/validations/secrets'

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -39,6 +39,9 @@ module ZendeskAppsSupport
         errors << Validations::Requirements.call(self)
         errors << Validations::Requests.call(self)
 
+        # only adds warnings
+        Validations::SecureSettings.call(self)
+
         unless manifest.requirements_only? || manifest.marketing_only? || manifest.iframe_only?
           errors << Validations::Templates.call(self)
           errors << Validations::Stylesheets.call(self)
@@ -49,7 +52,7 @@ module ZendeskAppsSupport
       errors << Validations::Svg.call(self) if has_svgs?
       errors << Validations::Mime.call(self)
 
-      # warning only validators
+      # only adds warnings
       Validations::Secrets.call(self)
 
       errors.flatten.compact

--- a/lib/zendesk_apps_support/validations/secure_settings.rb
+++ b/lib/zendesk_apps_support/validations/secure_settings.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module ZendeskAppsSupport
+  module Validations
+    module SecureSettings
+      SECURABLE_KEYWORDS = %w[token key pwd password].freeze
+      SECURABLE_KEYWORDS_REGEXP = Regexp.new(SECURABLE_KEYWORDS.join('|'), Regexp::IGNORECASE)
+
+      class << self
+        def call(package)
+          manifest_params = package.manifest.parameters
+
+          insecure_params_found = manifest_params.any? { |param| insecure_param?(param) }
+
+          package.warnings << secure_settings_warning if insecure_params_found
+        end
+
+        private
+
+        def insecure_param?(parameter)
+          parameter.name =~ SECURABLE_KEYWORDS_REGEXP && type_password_or_text?(parameter.type) && !parameter.secure
+        end
+
+        def type_password_or_text?(parameter_type)
+          parameter_type == 'text' || parameter_type == 'password'
+        end
+
+        def secure_settings_warning
+          I18n.t(
+            'txt.apps.admin.error.app_build.translation.insecure_token_parameter_in_manifest',
+            link: 'https://developer.zendesk.com/apps/docs/developer-guide/using_sdk#using-secure-settings'
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/zendesk_apps_support/validations/source.rb
+++ b/lib/zendesk_apps_support/validations/source.rb
@@ -6,7 +6,7 @@ module ZendeskAppsSupport
       class << self
         def call(package)
           if app_doesnt_require_source?(package.manifest) && contain_source_files?(package)
-            ValidationError.new(:no_code_for_ifo_notemplate)
+            ValidationError.new(:no_source_required_apps)
           end
         end
 

--- a/spec/validations/secure_settings_spec.rb
+++ b/spec/validations/secure_settings_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ZendeskAppsSupport::Validations::SecureSettings do
+  let(:package) { double('Package', warnings: []) }
+  let(:secured_param)  { ZendeskAppsSupport::Manifest::Parameter.new('name' => 'my_token', 'secure' => true) }
+  let(:insecure_param) { ZendeskAppsSupport::Manifest::Parameter.new('name' => 'my_token') }
+  let(:regular_param)  { ZendeskAppsSupport::Manifest::Parameter.new('name' => 'subdomain') }
+
+  context 'when manifest parameters do not contain SECURABLE_KEYWORDS' do
+    it 'returns no warning' do
+      allow(package).to receive_message_chain('manifest.parameters') { [regular_param] }
+      subject.call(package)
+
+      expect(package.warnings).to be_empty
+    end
+  end
+
+  context 'when manifest parameters contain SECURABLE_KEYWORDS' do
+    it 'returns a warning if secure key is false/undefined' do
+      allow(package).to receive_message_chain('manifest.parameters') { [ insecure_param, regular_param ] }
+      subject.call(package)
+
+      expect(package.warnings.size).to eq(1)
+      expect(package.warnings[0]).to include('Make sure to set secure to true')
+    end
+
+    it 'returns no warning if secure key is true' do
+      allow(package).to receive_message_chain('manifest.parameters') { [ secured_param, regular_param ] }
+      subject.call(package)
+
+      expect(package.warnings).to be_empty
+    end
+  end
+end

--- a/spec/validations/source_spec.rb
+++ b/spec/validations/source_spec.rb
@@ -19,7 +19,7 @@ describe ZendeskAppsSupport::Validations::Source do
     it 'returns validation error if package contains source files' do
       package.js_files << 'random_js_file.js'
 
-      expect(validation_error).to receive(:new).with(:no_code_for_ifo_notemplate)
+      expect(validation_error).to receive(:new).with(:no_source_required_apps)
     end
 
     it 'returns no validation error if package has no source files' do
@@ -37,7 +37,7 @@ describe ZendeskAppsSupport::Validations::Source do
     it 'returns validation error if package contains source files' do
       package.template_files << 'random_template.html'
 
-      expect(validation_error).to receive(:new).with(:no_code_for_ifo_notemplate)
+      expect(validation_error).to receive(:new).with(:no_source_required_apps)
     end
 
     it 'returns no validation error if package has no source files' do


### PR DESCRIPTION
## [MPORT-501]  Include secure settings check in validations

### Descriptions
We are adding a new **validation warning (non-blocking) to suggest** using secure settings IF developers have token or passwords as a parameter.

**Steps:**
1) Look at manifest parameter names
2) If any of them has the word "token", "key", or "password" in them, display this message.

    ![image](https://user-images.githubusercontent.com/17760485/61340064-10a66300-a884-11e9-83fb-5b443efacedb.png)
    Link: https://developer.zendesk.com/apps/docs/developer-guide/using_sdk#using-secure-settings

3) Update other strings that are not related to this PR.

**Todos:**
- [ ] Use translated strings before merging
- [x] Add spec
- [x] Clean up Commits from the 3 to 2 
- [x] Make sure [this](https://github.com/zendesk/zendesk_apps_support/pull/235) is merged first. 

### References
- https://zendesk.atlassian.net/browse/MPORT-501

### Risks
[low] Validation WARNING on secure settings doesn't work properly. 

[MPORT-501]: https://zendesk.atlassian.net/browse/MPORT-501