### PR TITLE
[MPORT-518] Give more information in secrets warnings

### DIFF
--- a/lib/zendesk_apps_support/validations/secrets.rb
+++ b/lib/zendesk_apps_support/validations/secrets.rb
@@ -60,7 +60,8 @@ module ZendeskAppsSupport
                                          secret_type: secret_type)
             end
 
-            file.relative_path if contents =~ Regexp.union(SECRET_KEYWORDS)
+            match = Regexp.union(SECRET_KEYWORDS).match(contents)
+            "#{file.relative_path} ('#{match[0]}...')" if match
           end.compact
 
           return unless compromised_files.any?

--- a/lib/zendesk_apps_support/validations/secrets.rb
+++ b/lib/zendesk_apps_support/validations/secrets.rb
@@ -4,8 +4,8 @@ module ZendeskAppsSupport
   module Validations
     module Secrets
       SECRET_KEYWORDS = %w[
-        pass password secret secretToken secret_token auth_key
-        authKey auth_pass authPass auth_user AuthUser username api_key
+        password secret secretToken secret_token auth_key
+        authKey auth_pass authPass auth_user AuthUser api_key
       ].freeze
 
       APPLICATION_SECRETS = {

--- a/spec/validations/secrets_spec.rb
+++ b/spec/validations/secrets_spec.rb
@@ -22,7 +22,7 @@ describe ZendeskAppsSupport::Validations::Secrets do
     it 'raises an appropriate generic secret warning' do
       subject.call(package)
       expect(package.warnings.length).to eq(1)
-      expect(package.warnings[0]).to include('secrets found', 'manifest.json')
+      expect(package.warnings[0]).to include('secrets found', 'manifest.json', 'api_key')
     end
   end
 
@@ -32,7 +32,7 @@ describe ZendeskAppsSupport::Validations::Secrets do
     it 'raise a single generic grouped warning' do
       subject.call(package)
       expect(package.warnings.length).to eq(1)
-      expect(package.warnings[0]).to include('secrets found', 'manifest.json', 'assets/iframe.html')
+      expect(package.warnings[0]).to include('secrets found', 'manifest.json', 'assets/iframe.html', 'api_key')
     end
   end
 


### PR DESCRIPTION
This PR adds a string to the secrets warning:
```
sgoedecke:private_app/ $ zat_dev validate                                                                                         [11:26:06]
     warning  Possible secrets found in assets/foo.js ('password...'), assets/shared.js ('secret...'). Consider reviewing the contents of these files before submitting your app.
    validate  OK
```

It also removes some keywords from the secret validation ('username' and 'pass') which I think are too liable to cause false positives. It's OK to have a username variable, and 'pass' is a substring of 'passed', which can come up a lot when writing code.

https://zendesk.atlassian.net/browse/MPORT-518