### PR TITLE
Fix incorrect IP regex

### DIFF
--- a/lib/zendesk_apps_support/validations/requests.rb
+++ b/lib/zendesk_apps_support/validations/requests.rb
@@ -7,7 +7,8 @@ module ZendeskAppsSupport
   module Validations
     module Requests
       class << self
-        IP_ADDRESS = /\b(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\b/
+        IP_ADDRESS =
+          /\b(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\b/
 
         def call(package)
           errors = []

--- a/lib/zendesk_apps_support/validations/requests.rb
+++ b/lib/zendesk_apps_support/validations/requests.rb
@@ -7,7 +7,7 @@ module ZendeskAppsSupport
   module Validations
     module Requests
       class << self
-        IP_ADDRESS = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
+        IP_ADDRESS = /\b(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\b/
 
         def call(package)
           errors = []

--- a/spec/validations/requests_spec.rb
+++ b/spec/validations/requests_spec.rb
@@ -40,6 +40,11 @@ describe ZendeskAppsSupport::Validations::Requests do
       expect(validation_error_class).to_not receive(:new)
     end
 
+    it 'returns no validation error when scanning invalid IP' do
+      allow(app_file).to receive(:read) { script_containing_ip('128.664.299.002') }
+      expect(validation_error_class).to_not receive(:new)
+    end
+
     it 'returns a validation error when scanning private IP' do
       private_ip = '192.168.0.1'
       allow(app_file).to receive(:read) { script_containing_ip(private_ip) }


### PR DESCRIPTION
Fixes incorrect IP regex causing error when running zat validate:

https://github.com/zendesk/zendesk_apps_tools/issues/313

```bash
$ zat package
/Library/Ruby/Gems/2.3.0/gems/ipaddress_2-0.13.0/lib/ipaddress_2/ipv4.rb:71:in `initialize': Invalid IP "128.664.299.002" (ArgumentError)
        from /Library/Ruby/Gems/2.3.0/gems/ipaddress_2-0.13.0/lib/ipaddress_2.rb:55:in `new'
        from /Library/Ruby/Gems/2.3.0/gems/ipaddress_2-0.13.0/lib/ipaddress_2.rb:55:in `parse'
        from /Library/Ruby/Gems/2.3.0/gems/zendesk_apps_support-4.21.1/lib/zendesk_apps_support/validations/requests.rb:55:in `blocked_ip_type'
        from /Library/Ruby/Gems/2.3.0/gems/zendesk_apps_support-4.21.1/lib/zendesk_apps_support/validations/requests.rb:41:in `block in blocked_ips_validation'
        from /Library/Ruby/Gems/2.3.0/gems/zendesk_apps_support-4.21.1/lib/zendesk_apps_support/validations/requests.rb:40:in `each'
        from /Library/Ruby/Gems/2.3.0/gems/zendesk_apps_support-4.21.1/lib/zendesk_apps_support/validations/requests.rb:40:in `each_with_object'
        from /Library/Ruby/Gems/2.3.0/gems/zendesk_apps_support-4.21.1/lib/zendesk_apps_support/validations/requests.rb:40:in `blocked_ips_validation'
        from /Library/Ruby/Gems/2.3.0/gems/zendesk_apps_support-4.21.1/lib/zendesk_apps_support/validations/requests.rb:30:in `block in call'
        from /Library/Ruby/Gems/2.3.0/gems/zendesk_apps_support-4.21.1/lib/zendesk_apps_support/validations/requests.rb:16:in `each'
        from /Library/Ruby/Gems/2.3.0/gems/zendesk_apps_support-4.21.1/lib/zendesk_apps_support/validations/requests.rb:16:in `call'
        from /Library/Ruby/Gems/2.3.0/gems/zendesk_apps_support-4.21.1/lib/zendesk_apps_support/package.rb:40:in `validate'
        from /Library/Ruby/Gems/2.3.0/gems/zendesk_apps_tools-3.2.1/lib/zendesk_apps_tools/command.rb:92:in `validate'
        from /Library/Ruby/Gems/2.3.0/gems/zendesk_apps_tools-3.2.1/lib/zendesk_apps_tools/command.rb:121:in `package'
        from /Library/Ruby/Gems/2.3.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
        from /Library/Ruby/Gems/2.3.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
        from /Library/Ruby/Gems/2.3.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
        from /Library/Ruby/Gems/2.3.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
        from /Library/Ruby/Gems/2.3.0/gems/zendesk_apps_tools-3.2.1/bin/zat:13:in `<top (required)>'
        from /usr/local/bin/zat:22:in `load'
        from /usr/local/bin/zat:22:in `<main>'
```
```bash
$ ruby -v
ruby 2.3.7p456 (2018-03-28 revision 63024) [universal.x86_64-darwin18]

```