### PR TITLE
[SAF-853] Divided contact_card location to person_card and company_card

### DIFF
--- a/lib/zendesk_apps_support/location.rb
+++ b/lib/zendesk_apps_support/location.rb
@@ -51,11 +51,15 @@ module ZendeskAppsSupport
       Location.new(id: 14, name: 'background',
                    product_code: Product::CHAT.code),
       Location.new(id: 15, name: 'deal_card', product_code: Product::SELL.code, collapsible: true),
-      Location.new(id: 16, name: 'contact_card', product_code: Product::SELL.code, collapsible: true),
-      Location.new(id: 17, name: 'lead_card', product_code: Product::SELL.code, collapsible: true),
-      Location.new(id: 18, name: 'background', product_code: Product::SELL.code),
-      Location.new(id: 19, name: 'modal', product_code: Product::SELL.code),
-      Location.new(id: 20, name: 'dashboard', product_code: Product::SELL.code)
+      Location.new(id: 16, name: 'person_card', product_code: Product::SELL.code, collapsible: true),
+      Location.new(id: 17, name: 'company_card', product_code: Product::SELL.code, collapsible: true),
+      Location.new(id: 18, name: 'lead_card', product_code: Product::SELL.code, collapsible: true),
+      Location.new(id: 19, name: 'background', product_code: Product::SELL.code),
+      Location.new(id: 20, name: 'modal', product_code: Product::SELL.code),
+      Location.new(id: 21, name: 'dashboard', product_code: Product::SELL.code),
+      Location.new(id: 22, name: 'note_editor', product_code: Product::SELL.code),
+      Location.new(id: 23, name: 'call_log_editor', product_code: Product::SELL.code),
+      Location.new(id: 24, name: 'email_editor', product_code: Product::SELL.code)
     ].freeze
   end
 end


### PR DESCRIPTION
We'd like to be more specific when saying whether app is displayed on person or on company contact. 

This PR removed previous `contact_card` and adds `person_card` and `company_card`.

@Mehul-Porwal Is this kind of change safe? I assume there's 0 apps with previously defined IDs, so that shouldn't be a problem, right?

This PR also adds a new location `editor` - this is simmilar to `ticket_editor` location in Support. We already have a potential app ideas, and since I'm messing with locations I added it now :)