### PR TITLE
Update Bundler version for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ branches:
   only: [master]
 env:
   - COMMAND=rake
+before_install:
+  - gem update --system
+  - gem install bundler
 matrix:
   include:
     - rvm: 2.4.0


### PR DESCRIPTION
Whenever anyone with bundler v2.x runs bundle, it updates the lockfile to match that and fails the build (since Travis doesn't have bundler 2.0 by default). We've been avoiding updating it in travis because projects using ZAS (e.g. ZAT) need to support ruby 2.1 and 2.2, which Bundler 2.0 does not. But you can bundle a gem with Bundler 2.0 and still use Bundler 1.x for projects using that gem. See the green build here: https://github.com/zendesk/zendesk_apps_tools/pull/317

This change should keep the build green.

@zendesk/dingo @zendesk/wattle