### PR TITLE
[MPORT-550] Lockdown Bundler version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ PLATFORMS
 
 DEPENDENCIES
   bump (~> 0.5.1)
+  bundler (= 1.17.3)
   byebug (~> 9.0.6)
   faker (~> 1.6.6)
   rspec (~> 3.4.0)
@@ -91,4 +92,4 @@ DEPENDENCIES
   zendesk_apps_support!
 
 BUNDLED WITH
-   2.0.1
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -9,10 +9,16 @@ This repo is owned and maintained by the Zendesk Apps team. You can reach us on 
 ## Getting Started
 When you want to help **develop** this tool, you will need to clone this repo.
 
+Since ZAS is used in ZAT, which supports Ruby 2.1, the Bundler Gem Version 1.17.3 is required for bundling dependencies. If you are working with a version that is higher than `1.17.3`, you will need to downgrade it.
+```
+  $ gem install bundler --version 1.17.3
+  $ bundle install
+```
+
 Very likely you want to try out your changes with the use of ZAT. See [ZAT](https://github.com/zendesk/zendesk_apps_tools/) for how to get ZAT/ZAS in development.
 
 ## Testing
-This project uses rspec, which can be run with `bundle exec rake`.
+This project uses Rspec, which can be run with `bundle exec rake`.
 
 ## Contribute
 * Put up a PR into the master branch.

--- a/zendesk_apps_support.gemspec
+++ b/zendesk_apps_support.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'faker', '~> 1.6.6'
   s.add_development_dependency 'rubocop', '~> 0.49.0'
   s.add_development_dependency 'byebug', '~> 9.0.6'
+  s.add_development_dependency 'bundler', '1.17.3'
 
   s.files = Dir.glob('{lib,config}/**/*') + %w[README.md LICENSE]
 end


### PR DESCRIPTION
**Description:**
In the past, Gemfile.lock's `BUNDLE WITH` gets bumped by accident, mostly from gem deploy commands or rake bump commands. If this version goes above 2.0.0, our travis build will fail because we support stone-age ruby.

Jira: https://zendesk.atlassian.net/browse/MPORT-550

**Risk:** 
- Low: Developers can't bundle ZAS dependencies