### PR TITLE
[MPORT-580] Change blockers to warnings for private apps IP requests

### DIFF
--- a/lib/zendesk_apps_support/validations/requests.rb
+++ b/lib/zendesk_apps_support/validations/requests.rb
@@ -12,45 +12,70 @@ module ZendeskAppsSupport
         def call(package)
           errors = []
           files = package.js_files + package.html_files
+          private_app = package.manifest.private?
 
           files.each do |file|
             file_content = file.read
 
             http_protocol_urls = find_address_containing_http(file_content)
             if http_protocol_urls.any?
-              package.warnings << I18n.t(
-                'txt.apps.admin.warning.app_build.insecure_http_request',
-                uri: http_protocol_urls.join(I18n.t('txt.apps.admin.error.app_build.listing_comma')),
-                file: file.relative_path
+              package.warnings << insecure_http_requests_warning(
+                http_protocol_urls,
+                file.relative_path
               )
             end
 
             ip_addresses = file_content.scan(IP_ADDRESS)
-            if ip_addresses.any?
-              errors << blocked_ips_validation(file.relative_path, ip_addresses)
-            end
+            next unless ip_addresses.any?
+
+            ip_validation_messages = ip_validation_messages(
+              file.relative_path,
+              ip_addresses,
+              private_app
+            )
+
+            validation_group = private_app ? package.warnings : errors
+            validation_group << ip_validation_messages
           end
 
+          package.warnings.flatten!
           errors
         end
 
         private
 
-        def blocked_ips_validation(file_path, ip_addresses)
-          ip_addresses.each_with_object([]) do |ip_address, error_messages|
-            blocked_type = blocked_ip_type(ip_address)
-            next unless blocked_type
+        def ip_validation_messages(file_path, ip_addresses, private_app)
+          ip_addresses.each_with_object([]) do |ip_address, messages|
+            ip_type_string = ip_type_string(ip_address)
+            next unless ip_type_string
 
-            error_messages << ValidationError.new(
-              :blocked_request,
-              type: blocked_type,
-              uri:  ip_address,
-              file: file_path
-            )
+            string_params = {
+              type: ip_type_string, uri: ip_address, file: file_path
+            }
+            validation_message =
+              if private_app
+                I18n.t('txt.apps.admin.error.app_build.blocked_request', string_params)
+              else
+                ValidationError.new(:blocked_request, string_params)
+              end
+
+            messages << validation_message
           end
         end
 
-        def blocked_ip_type(ip_address)
+        def insecure_http_requests_warning(http_protocol_urls, relative_path)
+          http_protocol_urls = http_protocol_urls.join(
+            I18n.t('txt.apps.admin.error.app_build.listing_comma')
+          )
+
+          I18n.t(
+            'txt.apps.admin.warning.app_build.insecure_http_request',
+            uri: http_protocol_urls,
+            file: relative_path
+          )
+        end
+
+        def ip_type_string(ip_address)
           block_type =
             case IPAddress.parse(ip_address)
             when proc(&:private?) then 'private'


### PR DESCRIPTION
cc: @zendesk/dingo @zendesk/wattle-dev  

[Private flag in app manifest is true by default. If a developer wishes to publish an app to the marketplace, this flag is set to false.](https://developer.zendesk.com/apps/docs/developer-guide/manifest#private)

In this implementation, when an app is private, these strings will show up as warnings instead. 

Jira: https://zendesk.atlassian.net/browse/MPORT-580

Risk: Low - App upload is blocked or fails