### PR TITLE
[MPORT-600] Add validation for custom object types and relationships

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,7 +36,7 @@ Metrics/BlockLength:
   
 Metrics/ModuleLength:
   CountComments: false  # count full line comments?
-  Max: 130
+  Max: 200
 
 CommentAnnotation:
   Keywords:

--- a/lib/zendesk_apps_support/app_requirement.rb
+++ b/lib/zendesk_apps_support/app_requirement.rb
@@ -2,7 +2,7 @@
 
 module ZendeskAppsSupport
   class AppRequirement
-    TYPES = %w[automations channel_integrations custom_resources_schema macros targets views ticket_fields
+    TYPES = %w[automations channel_integrations custom_objects macros targets views ticket_fields
                triggers user_fields organization_fields].freeze
   end
 end

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -126,7 +126,7 @@ module ZendeskAppsSupport
         def validate_custom_objects_keys(keys, expected_keys, identifier, errors = [])
           invalid_keys = keys - expected_keys
           unless invalid_keys.empty?
-            errors << ValidationError.new(:invalid_cr_schema_keys, # TODO: update error translations
+            errors << ValidationError.new(:invalid_custom_objects_schema_keys,
                                           invalid_keys: invalid_keys.join(', '),
                                           count: invalid_keys.length)
           end

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -136,12 +136,6 @@ module ZendeskAppsSupport
         end
 
         def validate_custom_objects_keys(keys, expected_keys, identifier, errors = [])
-          invalid_keys = keys - expected_keys
-          unless invalid_keys.empty?
-            errors << ValidationError.new(:invalid_custom_objects_schema_keys,
-                                          invalid_keys: invalid_keys.join(', '),
-                                          count: invalid_keys.length)
-          end
           missing_keys = expected_keys - keys
           missing_keys.each do |key|
             errors << ValidationError.new(:missing_required_fields,

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -46,7 +46,7 @@ module ZendeskAppsSupport
             requirements.each do |requirement_type, requirement|
               next if %w[channel_integrations custom_objects].include? requirement_type
               requirement.each do |identifier, fields|
-                next if fields.include? 'title'
+                next if fields.nil? || fields.include?('title')
                 errors << ValidationError.new(:missing_required_fields,
                                               field: 'title',
                                               identifier: identifier)
@@ -56,7 +56,9 @@ module ZendeskAppsSupport
         end
 
         def excessive_requirements(requirements)
-          count = requirements.values.map(&:values).flatten.size
+          count = requirements.values.map do |req|
+            req.is_a?(Hash) ? req.values : req
+          end.flatten.size
           ValidationError.new(:excessive_requirements, max: MAX_REQUIREMENTS, count: count) if count > MAX_REQUIREMENTS
         end
 

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -4,7 +4,7 @@ module ZendeskAppsSupport
   module Validations
     module Requirements
       MAX_REQUIREMENTS = 5000
-      MAX_CUSTOM_OBJECTS_REQUIREMENTS = 10
+      MAX_CUSTOM_OBJECTS_REQUIREMENTS = 50
 
       class << self
         def call(package)

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -111,13 +111,17 @@ module ZendeskAppsSupport
           custom_objects = requirements['custom_objects']
           return if custom_objects.nil?
 
-          valid_schema = {
-            'custom_object_types' => %w[key schema],
-            'custom_object_relationship_types' => %w[key source target]
-          }
-
           [].tap do |errors|
-            validate_custom_objects_keys(custom_objects.keys, valid_schema.keys, 'custom_objects', errors)
+            unless custom_objects.key?('custom_object_types')
+              errors << ValidationError.new(:missing_required_fields,
+                                            field: 'custom_object_types',
+                                            identifier: 'custom_objects')
+            end
+
+            valid_schema = {
+              'custom_object_types' => %w[key schema],
+              'custom_object_relationship_types' => %w[key source target]
+            }
 
             valid_schema.keys.each do |requirement_type|
               (custom_objects[requirement_type] || []).each do |requirement|

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -66,7 +66,8 @@ module ZendeskAppsSupport
 
         def excessive_custom_objects_requirements(requirements)
           custom_objects = requirements['custom_objects']
-          return if custom_objects.nil?
+          return unless custom_objects
+
           count = custom_objects.values.flatten.size
           if count > MAX_CUSTOM_OBJECTS_REQUIREMENTS
             ValidationError.new(:excessive_custom_objects_requirements, max: MAX_CUSTOM_OBJECTS_REQUIREMENTS,

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -97,8 +97,8 @@ module ZendeskAppsSupport
           return unless custom_objects
 
           valid_schema = {
-            'custom_object_types' => ['key', 'schema'],
-            'custom_object_relationship_types' => ['key', 'source', 'target']
+            'custom_object_types' => %w[key schema],
+            'custom_object_relationship_types' => %w[key source target]
           }
 
           [].tap do |errors|
@@ -121,9 +121,7 @@ module ZendeskAppsSupport
           end
         end
 
-        private
-
-        def validate_custom_objects_keys(keys, expected_keys, identifier, errors=[])
+        def validate_custom_objects_keys(keys, expected_keys, identifier, errors = [])
           invalid_keys = keys - expected_keys
           unless invalid_keys.empty?
             errors << ValidationError.new(:invalid_cr_schema_keys, # TODO: update error translations

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -4,6 +4,7 @@ module ZendeskAppsSupport
   module Validations
     module Requirements
       MAX_REQUIREMENTS = 5000
+      MAX_CUSTOM_OBJECTS_REQUIREMENTS = 10
 
       class << self
         def call(package)
@@ -24,6 +25,7 @@ module ZendeskAppsSupport
           [].tap do |errors|
             errors << invalid_requirements_types(requirements)
             errors << excessive_requirements(requirements)
+            errors << excessive_custom_objects_requirements(requirements)
             errors << invalid_channel_integrations(requirements)
             errors << invalid_custom_fields(requirements)
             errors << invalid_custom_objects(requirements)
@@ -60,6 +62,16 @@ module ZendeskAppsSupport
             req.is_a?(Hash) ? req.values : req
           end.flatten.size
           ValidationError.new(:excessive_requirements, max: MAX_REQUIREMENTS, count: count) if count > MAX_REQUIREMENTS
+        end
+
+        def excessive_custom_objects_requirements(requirements)
+          custom_objects = requirements['custom_objects']
+          return if custom_objects.nil?
+          count = custom_objects.values.flatten.size
+          if count > MAX_CUSTOM_OBJECTS_REQUIREMENTS
+            ValidationError.new(:excessive_custom_objects_requirements, max: MAX_CUSTOM_OBJECTS_REQUIREMENTS,
+                                                                        count: count)
+          end
         end
 
         def invalid_custom_fields(requirements)

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -109,7 +109,7 @@ module ZendeskAppsSupport
 
         def invalid_custom_objects(requirements)
           custom_objects = requirements['custom_objects']
-          return unless custom_objects
+          return if custom_objects.nil?
 
           valid_schema = {
             'custom_object_types' => %w[key schema],

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -201,9 +201,10 @@ describe ZendeskAppsSupport::Validations::Requirements do
           'custom_objects' => {
             'custom_object_types' => [
               'key' => 'foo',
-              'schema' => {},
+              'schema' => {}
             ],
-            'custom_object_relationship_types' => [] }
+            'custom_object_relationship_types' => []
+          }
         )
       end
 
@@ -229,7 +230,10 @@ describe ZendeskAppsSupport::Validations::Requirements do
       let(:requirements_string) do
         JSON.generate(
           'custom_objects' => {
-            'custom_object_types' => [], 'custom_object_relationship_types' => [], 'resources' => [], 'relationships' => []
+            'custom_object_types' => [],
+            'custom_object_relationship_types' => [],
+            'resources' => [],
+            'relationships' => []
           }
         )
       end

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -255,24 +255,6 @@ describe ZendeskAppsSupport::Validations::Requirements do
       end
     end
 
-    context 'a custom objects schema contains invalid keys' do
-      let(:requirements_string) do
-        JSON.generate(
-          'custom_objects' => {
-            'custom_object_types' => [],
-            'custom_object_relationship_types' => [],
-            'resources' => [],
-            'relationships' => []
-          }
-        )
-      end
-
-      it 'creates an error' do
-        expect(errors.first.key).to eq(:invalid_custom_objects_schema_keys)
-        expect(errors.first.data).to eq(invalid_keys: 'resources, relationships', count: 2)
-      end
-    end
-
     context 'a custom objects schema is missing custom_object_types' do
       let(:requirements_string) { JSON.generate('custom_objects' => { 'custom_object_relationship_types' => [] }) }
 

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -89,13 +89,13 @@ describe ZendeskAppsSupport::Validations::Requirements do
           custom_object_relationships: []
         }
       }
-      5.times do
+      25.times do
         requirements_content[:custom_objects][:custom_object_types] << {
           key: 'foo',
           schema: {}
         }
       end
-      6.times do
+      26.times do
         requirements_content[:custom_objects][:custom_object_relationships] << {
           key: 'foo',
           source: 'bar',

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -194,48 +194,68 @@ describe ZendeskAppsSupport::Validations::Requirements do
     end
   end
 
-  context 'there is a valid custom resources schema defined' do
-    let(:requirements_string) do
-      JSON.generate(
-        'custom_resources_schema' => { 'resource_types' => [], 'relationship_types' => [] }
-      )
+  context 'custom object requirements validations' do
+    context 'there is a valid custom objects schema defined' do
+      let(:requirements_string) do
+        JSON.generate(
+          'custom_objects' => {
+            'custom_object_types' => [
+              'key' => 'foo',
+              'schema' => {},
+            ],
+            'custom_object_relationship_types' => [] }
+        )
+      end
+
+      it 'does not return an error' do
+        expect(errors).to be_empty
+      end
     end
 
-    it 'does not return an error' do
-      expect(errors).to be_empty
+    context 'a custom objects schema contains invalid type-level keys' do
+      let(:requirements_string) do
+        JSON.generate(
+          'custom_objects' => { 'custom_object_types' => [{}], 'custom_object_relationship_types' => [] }
+        )
+      end
+
+      it 'creates an error' do
+        expect(errors.first.key).to eq(:missing_required_fields)
+        expect(errors.first.data).to eq(field: 'key', identifier: 'custom_object_types')
+      end
     end
-  end
 
-  context 'a custom resources schema contains invalid keys' do
-    let(:requirements_string) do
-      JSON.generate(
-        'custom_resources_schema' => {
-          'resource_types' => [], 'relationship_types' => [], 'resources' => [], 'relationships' => []
-        }
-      )
+    context 'a custom objects schema contains invalid keys' do
+      let(:requirements_string) do
+        JSON.generate(
+          'custom_objects' => {
+            'custom_object_types' => [], 'custom_object_relationship_types' => [], 'resources' => [], 'relationships' => []
+          }
+        )
+      end
+
+      it 'creates an error' do
+        expect(errors.first.key).to eq(:invalid_cr_schema_keys)
+        expect(errors.first.data).to eq(invalid_keys: 'resources, relationships', count: 2)
+      end
     end
 
-    it 'creates an error' do
-      expect(errors.first.key).to eq(:invalid_cr_schema_keys)
-      expect(errors.first.data).to eq(invalid_keys: 'resources, relationships', count: 2)
+    context 'a custom objects schema is missing custom_object_types' do
+      let(:requirements_string) { JSON.generate('custom_objects' => { 'custom_object_relationship_types' => [] }) }
+
+      it 'creates an error' do
+        expect(errors.first.key).to eq(:missing_required_fields)
+        expect(errors.first.data).to eq(field: 'custom_object_types', identifier: 'custom_objects')
+      end
     end
-  end
 
-  context 'a custom resources schema is missing resource_types' do
-    let(:requirements_string) { JSON.generate('custom_resources_schema' => { 'relationship_types' => [] }) }
+    context 'a custom objects schema is missing custom_object_relationship_types' do
+      let(:requirements_string) { JSON.generate('custom_objects' => { 'custom_object_types' => [] }) }
 
-    it 'creates an error' do
-      expect(errors.first.key).to eq(:missing_required_fields)
-      expect(errors.first.data).to eq(field: 'resource_types', identifier: 'custom_resources_schema')
-    end
-  end
-
-  context 'a custom resources schema is missing relationship_types' do
-    let(:requirements_string) { JSON.generate('custom_resources_schema' => { 'resource_types' => [] }) }
-
-    it 'creates an error' do
-      expect(errors.first.key).to eq(:missing_required_fields)
-      expect(errors.first.data).to eq(field: 'relationship_types', identifier: 'custom_resources_schema')
+      it 'creates an error' do
+        expect(errors.first.key).to eq(:missing_required_fields)
+        expect(errors.first.data).to eq(field: 'custom_object_relationship_types', identifier: 'custom_objects')
+      end
     end
   end
 end

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -239,7 +239,7 @@ describe ZendeskAppsSupport::Validations::Requirements do
       end
 
       it 'creates an error' do
-        expect(errors.first.key).to eq(:invalid_cr_schema_keys)
+        expect(errors.first.key).to eq(:invalid_custom_objects_schema_keys)
         expect(errors.first.data).to eq(invalid_keys: 'resources, relationships', count: 2)
       end
     end

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -267,9 +267,8 @@ describe ZendeskAppsSupport::Validations::Requirements do
     context 'a custom objects schema is missing custom_object_relationship_types' do
       let(:requirements_string) { JSON.generate('custom_objects' => { 'custom_object_types' => [] }) }
 
-      it 'creates an error' do
-        expect(errors.first.key).to eq(:missing_required_fields)
-        expect(errors.first.data).to eq(field: 'custom_object_relationship_types', identifier: 'custom_objects')
+      it 'does not create an error' do
+        expect(errors).to be_empty
       end
     end
   end

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -81,6 +81,35 @@ describe ZendeskAppsSupport::Validations::Requirements do
     end
   end
 
+  context 'there are more than 10 custom objects requirements' do
+    let(:requirements_string) do
+      requirements_content = {
+        custom_objects: {
+          custom_object_types: [],
+          custom_object_relationships: []
+        }
+      }
+      5.times do
+        requirements_content[:custom_objects][:custom_object_types] << {
+          key: 'foo',
+          schema: {}
+        }
+      end
+      6.times do
+        requirements_content[:custom_objects][:custom_object_relationships] << {
+          key: 'foo',
+          source: 'bar',
+          target: 'baz'
+        }
+      end
+      JSON.generate(requirements_content)
+    end
+
+    it 'creates an error' do
+      expect(errors.first.key).to eq(:excessive_custom_objects_requirements)
+    end
+  end
+
   context 'a requirement field missing a "key"' do
     let(:requirements_string) { JSON.generate('targets' => { 'abc' => {} }) }
 


### PR DESCRIPTION
Adds validation for custom object requirements, against this schema:
```
{
  custom_objects: {
    custom_object_types: [ { key: 'dog', schema: {...}} ],
    custom_object_relationship_types: [ { key: 'dogs-join-cats', source: 'dog', target: 'cat' } ]
  }
}
```

Output:
```
sgoedecke@-:~/Code/zendesk/zendesk_apps_tools|master⚡
⇒  bundle exec zat validate --path=/Users/sgoedecke/Desktop/apps/private_app_with_custom_object_types
    validate  Missing required fields in requirements.json: "key" is required in "custom_object_types"
    validate  Missing required fields in requirements.json: "schema" is required in "custom_object_types"

sgoedecke@-:~/Code/zendesk/zendesk_apps_tools|master⚡
⇒ bundle exec zat validate --path=/Users/sgoedecke/Desktop/apps/private_app_with_custom_object_types
    validate  requirements.json contains an invalid type: custom_object_types

sgoedecke@-:~/Code/zendesk/zendesk_apps_tools|master⚡
⇒ bundle exec zat validate --path=/Users/sgoedecke/Desktop/apps/private_app_with_custom_object_types
    validate  Custom objects schema contains an invalid key: asdigfasdf

```
