### PR TITLE
[MPORT-600] Add string for too many custom object requirements

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,9 @@ en:
             requirements_not_json: requirements.json is not proper JSON. %{errors}
             excessive_requirements: The requirements.json file contains too many requirements.
               The current limit is %{max} requirements. This app has %{count} requirements.
+            excessive_custom_objects_requirements: The requirements.json file contains
+              too many custom objects requirements. The current limit is %{max} requirements.
+              This app has %{count} requirements.
             missing_required_fields: 'Missing required fields in requirements.json:
               "%{field}" is required in "%{identifier}"'
             duplicate_requirements:

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -103,7 +103,7 @@ parts:
       value: "The requirements.json file contains too many requirements. The current limit is %{max} requirements. This app has %{count} requirements."
   - translation:
       key: "txt.apps.admin.error.app_build.excessive_custom_objects_requirements"
-      title: "App builder job: requirements file contains too many custom objects requirements"
+      title: "App builder job: requirements file contains too many custom objects requirements. Leave requirements.json as is (do not localize)"
       value: "The requirements.json file contains too many custom objects requirements. The current limit is %{max} requirements. This app has %{count} requirements."
   - translation:
       key: "txt.apps.admin.error.app_build.missing_required_fields"

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -105,6 +105,7 @@ parts:
       key: "txt.apps.admin.error.app_build.excessive_custom_objects_requirements"
       title: "App builder job: requirements file contains too many custom objects requirements. Leave requirements.json as is (do not localize)"
       value: "The requirements.json file contains too many custom objects requirements. The current limit is %{max} requirements. This app has %{count} requirements."
+      screenshot: "https://drive.google.com/open?id=18yac8rV7kMe5qm49ERVFVCA7WOZl8vcP"
   - translation:
       key: "txt.apps.admin.error.app_build.missing_required_fields"
       title: "App builder job: required key missing in requirements, e.g. \"title\" is required in \"my_custom_email_target\""

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -102,6 +102,10 @@ parts:
       title: "App builder job: requirements file contains too many requirements"
       value: "The requirements.json file contains too many requirements. The current limit is %{max} requirements. This app has %{count} requirements."
   - translation:
+      key: "txt.apps.admin.error.app_build.excessive_custom_objects_requirements"
+      title: "App builder job: requirements file contains too many custom objects requirements"
+      value: "The requirements.json file contains too many custom objects requirements. The current limit is %{max} requirements. This app has %{count} requirements."
+  - translation:
       key: "txt.apps.admin.error.app_build.missing_required_fields"
       title: "App builder job: required key missing in requirements, e.g. \"title\" is required in \"my_custom_email_target\""
       value: "Missing required fields in requirements.json: \"%{field}\" is required in \"%{identifier}\""


### PR DESCRIPTION
We're limiting the number of custom object requirements for EAP to some yet to be determined number. We need a validation string for that (and for whatever the eventual GA limit will be).

https://drive.google.com/open?id=18yac8rV7kMe5qm49ERVFVCA7WOZl8vcP