### PR TITLE
[DINGO-651] Add custom_object_requirements helper method

### DIFF
--- a/lib/zendesk_apps_support/app_requirement.rb
+++ b/lib/zendesk_apps_support/app_requirement.rb
@@ -2,6 +2,9 @@
 
 module ZendeskAppsSupport
   class AppRequirement
+    CUSTOM_OBJECTS_KEY = 'custom_objects'
+    CUSTOM_OBJECTS_TYPE_KEY = 'custom_object_types'
+    CUSTOM_OBJECTS_RELATIONSHIP_TYPE_KEY = 'custom_object_relationship_types'
     TYPES = %w[automations channel_integrations custom_objects macros targets views ticket_fields
                triggers user_fields organization_fields].freeze
   end

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -12,8 +12,8 @@ module ZendeskAppsSupport
     MANIFEST_FILENAME = 'manifest.json'
     REQUIREMENTS_FILENAME = 'requirements.json'
     CUSTOM_OBJECTS_REQUIREMENT_KEY = 'custom_objects'
-    CUSTOM_OBJECTS_REQUIREMENT_TYPE = 'custom_object_types'
-    CUSTOM_OBJECTS_RELATIONSHIP_TYPE = 'custom_object_relationship_types'
+    CUSTOM_OBJECTS_REQUIREMENT_TYPE_KEY = 'custom_object_types'
+    CUSTOM_OBJECTS_RELATIONSHIP_TYPE_KEY = 'custom_object_relationship_types'
 
     DEFAULT_LAYOUT = Erubis::Eruby.new(File.read(File.expand_path('../assets/default_template.html.erb', __FILE__)))
     DEFAULT_SCSS   = File.read(File.expand_path('../assets/default_styles.scss', __FILE__))
@@ -217,12 +217,10 @@ module ZendeskAppsSupport
 
     def self.has_custom_object_requirements?(requirements_hash)
       custom_objects = requirements_hash && requirements_hash[CUSTOM_OBJECTS_REQUIREMENT_KEY] || {}
-      types = custom_objects[CUSTOM_OBJECTS_REQUIREMENT_TYPE]
-      relationships = custom_objects[CUSTOM_OBJECTS_RELATIONSHIP_TYPE]
+      types = custom_objects[CUSTOM_OBJECTS_REQUIREMENT_TYPE_KEY]
+      relationships = custom_objects[CUSTOM_OBJECTS_RELATIONSHIP_TYPE_KEY]
 
-      return true if types && types.any?
-      return true if relationships && relationships.any?
-      false
+      (types && types.any?) || (relationships && relationships.any?)
     end
 
     def app_css

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -11,9 +11,6 @@ module ZendeskAppsSupport
 
     MANIFEST_FILENAME = 'manifest.json'
     REQUIREMENTS_FILENAME = 'requirements.json'
-    CUSTOM_OBJECTS_REQUIREMENT_KEY = 'custom_objects'
-    CUSTOM_OBJECTS_REQUIREMENT_TYPE_KEY = 'custom_object_types'
-    CUSTOM_OBJECTS_RELATIONSHIP_TYPE_KEY = 'custom_object_relationship_types'
 
     DEFAULT_LAYOUT = Erubis::Eruby.new(File.read(File.expand_path('../assets/default_template.html.erb', __FILE__)))
     DEFAULT_SCSS   = File.read(File.expand_path('../assets/default_styles.scss', __FILE__))
@@ -218,9 +215,9 @@ module ZendeskAppsSupport
     def self.has_custom_object_requirements?(requirements_hash)
       return false if requirements_hash.nil?
 
-      custom_object_requirements = requirements_hash.fetch(CUSTOM_OBJECTS_REQUIREMENT_KEY, {})
-      types = custom_object_requirements.fetch(CUSTOM_OBJECTS_REQUIREMENT_TYPE_KEY, [])
-      relationships = custom_object_requirements.fetch(CUSTOM_OBJECTS_RELATIONSHIP_TYPE_KEY, [])
+      custom_object_requirements = requirements_hash.fetch(AppRequirement::CUSTOM_OBJECTS_KEY, {})
+      types = custom_object_requirements.fetch(AppRequirement::CUSTOM_OBJECTS_TYPE_KEY, [])
+      relationships = custom_object_requirements.fetch(AppRequirement::CUSTOM_OBJECTS_RELATIONSHIP_TYPE_KEY, [])
 
       (types | relationships).any?
     end

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -220,7 +220,9 @@ module ZendeskAppsSupport
       types = custom_objects[CUSTOM_OBJECTS_REQUIREMENT_TYPE_KEY]
       relationships = custom_objects[CUSTOM_OBJECTS_RELATIONSHIP_TYPE_KEY]
 
-      (types && types.any?) || (relationships && relationships.any?)
+      return true if types && types.any?
+      return true if relationships && relationships.any?
+      false
     end
 
     def app_css

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -11,6 +11,9 @@ module ZendeskAppsSupport
 
     MANIFEST_FILENAME = 'manifest.json'
     REQUIREMENTS_FILENAME = 'requirements.json'
+    CUSTOM_OBJECTS_REQUIREMENT_KEY = 'custom_objects'
+    CUSTOM_OBJECTS_REQUIREMENT_TYPE = 'custom_object_types'
+    CUSTOM_OBJECTS_RELATIONSHIP_TYPE = 'custom_object_relationship_types'
 
     DEFAULT_LAYOUT = Erubis::Eruby.new(File.read(File.expand_path('../assets/default_template.html.erb', __FILE__)))
     DEFAULT_SCSS   = File.read(File.expand_path('../assets/default_styles.scss', __FILE__))
@@ -210,6 +213,16 @@ module ZendeskAppsSupport
 
     def has_requirements?
       has_file?(REQUIREMENTS_FILENAME)
+    end
+
+    def self.has_custom_object_requirements?(requirements_hash)
+      custom_objects = requirements_hash && requirements_hash[CUSTOM_OBJECTS_REQUIREMENT_KEY] || {}
+      types = custom_objects[CUSTOM_OBJECTS_REQUIREMENT_TYPE]
+      relationships = custom_objects[CUSTOM_OBJECTS_RELATIONSHIP_TYPE]
+
+      return true if types && types.any?
+      return true if relationships && relationships.any?
+      false
     end
 
     def app_css

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -216,13 +216,13 @@ module ZendeskAppsSupport
     end
 
     def self.has_custom_object_requirements?(requirements_hash)
-      custom_objects = requirements_hash && requirements_hash[CUSTOM_OBJECTS_REQUIREMENT_KEY] || {}
-      types = custom_objects[CUSTOM_OBJECTS_REQUIREMENT_TYPE_KEY]
-      relationships = custom_objects[CUSTOM_OBJECTS_RELATIONSHIP_TYPE_KEY]
+      return false if requirements_hash.nil?
 
-      return true if types && types.any?
-      return true if relationships && relationships.any?
-      false
+      custom_object_requirements = requirements_hash.fetch(CUSTOM_OBJECTS_REQUIREMENT_KEY, {})
+      types = custom_object_requirements.fetch(CUSTOM_OBJECTS_REQUIREMENT_TYPE_KEY, [])
+      relationships = custom_object_requirements.fetch(CUSTOM_OBJECTS_RELATIONSHIP_TYPE_KEY, [])
+
+      (types | relationships).any?
     end
 
     def app_css

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -65,7 +65,7 @@ module ZendeskAppsSupport
         end
 
         def excessive_custom_objects_requirements(requirements)
-          custom_objects = requirements[Package::CUSTOM_OBJECTS_REQUIREMENT_KEY]
+          custom_objects = requirements[AppRequirement::CUSTOM_OBJECTS_KEY]
           return unless custom_objects
 
           count = custom_objects.values.flatten.size
@@ -108,19 +108,19 @@ module ZendeskAppsSupport
         end
 
         def invalid_custom_objects(requirements)
-          custom_objects = requirements[Package::CUSTOM_OBJECTS_REQUIREMENT_KEY]
+          custom_objects = requirements[AppRequirement::CUSTOM_OBJECTS_KEY]
           return if custom_objects.nil?
 
           [].tap do |errors|
-            unless custom_objects.key?(Package::CUSTOM_OBJECTS_REQUIREMENT_TYPE_KEY)
+            unless custom_objects.key?(AppRequirement::CUSTOM_OBJECTS_TYPE_KEY)
               errors << ValidationError.new(:missing_required_fields,
-                                            field: Package::CUSTOM_OBJECTS_REQUIREMENT_TYPE_KEY,
-                                            identifier: Package::CUSTOM_OBJECTS_REQUIREMENT_KEY)
+                                            field: AppRequirement::CUSTOM_OBJECTS_TYPE_KEY,
+                                            identifier: AppRequirement::CUSTOM_OBJECTS_KEY)
             end
 
             valid_schema = {
-              Package::CUSTOM_OBJECTS_REQUIREMENT_TYPE_KEY => %w[key schema],
-              Package::CUSTOM_OBJECTS_RELATIONSHIP_TYPE_KEY => %w[key source target]
+              AppRequirement::CUSTOM_OBJECTS_TYPE_KEY => %w[key schema],
+              AppRequirement::CUSTOM_OBJECTS_RELATIONSHIP_TYPE_KEY => %w[key source target]
             }
 
             valid_schema.keys.each do |requirement_type|

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -65,7 +65,7 @@ module ZendeskAppsSupport
         end
 
         def excessive_custom_objects_requirements(requirements)
-          custom_objects = requirements['custom_objects']
+          custom_objects = requirements[Package::CUSTOM_OBJECTS_REQUIREMENT_KEY]
           return unless custom_objects
 
           count = custom_objects.values.flatten.size
@@ -108,19 +108,19 @@ module ZendeskAppsSupport
         end
 
         def invalid_custom_objects(requirements)
-          custom_objects = requirements['custom_objects']
+          custom_objects = requirements[Package::CUSTOM_OBJECTS_REQUIREMENT_KEY]
           return if custom_objects.nil?
 
           [].tap do |errors|
-            unless custom_objects.key?('custom_object_types')
+            unless custom_objects.key?(Package::CUSTOM_OBJECTS_REQUIREMENT_TYPE)
               errors << ValidationError.new(:missing_required_fields,
-                                            field: 'custom_object_types',
-                                            identifier: 'custom_objects')
+                                            field: Package::CUSTOM_OBJECTS_REQUIREMENT_TYPE,
+                                            identifier: Package::CUSTOM_OBJECTS_REQUIREMENT_KEY)
             end
 
             valid_schema = {
-              'custom_object_types' => %w[key schema],
-              'custom_object_relationship_types' => %w[key source target]
+              Package::CUSTOM_OBJECTS_REQUIREMENT_TYPE => %w[key schema],
+              Package::CUSTOM_OBJECTS_RELATIONSHIP_TYPE => %w[key source target]
             }
 
             valid_schema.keys.each do |requirement_type|

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -112,15 +112,15 @@ module ZendeskAppsSupport
           return if custom_objects.nil?
 
           [].tap do |errors|
-            unless custom_objects.key?(Package::CUSTOM_OBJECTS_REQUIREMENT_TYPE)
+            unless custom_objects.key?(Package::CUSTOM_OBJECTS_REQUIREMENT_TYPE_KEY)
               errors << ValidationError.new(:missing_required_fields,
-                                            field: Package::CUSTOM_OBJECTS_REQUIREMENT_TYPE,
+                                            field: Package::CUSTOM_OBJECTS_REQUIREMENT_TYPE_KEY,
                                             identifier: Package::CUSTOM_OBJECTS_REQUIREMENT_KEY)
             end
 
             valid_schema = {
-              Package::CUSTOM_OBJECTS_REQUIREMENT_TYPE => %w[key schema],
-              Package::CUSTOM_OBJECTS_RELATIONSHIP_TYPE => %w[key source target]
+              Package::CUSTOM_OBJECTS_REQUIREMENT_TYPE_KEY => %w[key schema],
+              Package::CUSTOM_OBJECTS_RELATIONSHIP_TYPE_KEY => %w[key source target]
             }
 
             valid_schema.keys.each do |requirement_type|

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -60,6 +60,35 @@ describe ZendeskAppsSupport::Package do
       expect(described_class.has_custom_object_requirements?(requirements_hash)).to be(false)
     end
 
+    it 'should return true when custom object types are present but relationships types are not defined' do
+      requirements_hash = {
+        'custom_objects' => {
+          'custom_object_types' => [
+            {
+              'key' => 'product',
+              'schema' => { 'properties' => { 'id' => { 'type' => 'string' } } }
+            }
+          ],
+          'custom_object_relationship_types' => []
+        }
+      }
+
+      expect(described_class.has_custom_object_requirements?(requirements_hash)).to be(true)
+    end
+
+    it 'should return true when custom object relationship types are present but custom object types are not defined' do
+      requirements_hash = {
+        'custom_objects' => {
+          'custom_object_types' => [],
+          'custom_object_relationship_types' => [
+            { 'key' => 'a', 'source' => 'b', 'target' => 'a' }
+          ]
+        }
+      }
+
+      expect(described_class.has_custom_object_requirements?(requirements_hash)).to be(true)
+    end
+
     it 'should return false when custom requirements empty' do
       requirements_hash = {
         'custom_objects' => {}

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -13,6 +13,74 @@ describe ZendeskAppsSupport::Package do
     end
   end
 
+  describe 'has_custom_object_requirements?' do
+    it 'should return true when custom object types are present' do
+      requirements_hash = {
+        'custom_objects' => {
+          'custom_object_types' => [
+            {
+              'key' => 'product',
+              'schema' => { 'properties' => { 'id' => { 'type' => 'string' } } }
+            }
+          ]
+        }
+      }
+      expect(described_class.has_custom_object_requirements?(requirements_hash)).to be(true)
+    end
+
+    it 'should return true when custom object relationships are present' do
+      requirements_hash = {
+        'custom_objects' => {
+          'custom_object_relationship_types' => [
+            { 'key' => 'a', 'source' => 'b', 'target' => 'a' }
+          ]
+        }
+      }
+
+      expect(described_class.has_custom_object_requirements?(requirements_hash)).to be(true)
+    end
+
+    it 'should return false when custom object types are not present' do
+      requirements_hash = {
+        'custom_objects' => {
+          'custom_object_types' => []
+        }
+      }
+
+      expect(described_class.has_custom_object_requirements?(requirements_hash)).to be(false)
+    end
+
+    it 'should return false when custom object relationships are not present' do
+      requirements_hash = {
+        'custom_objects' => {
+          'custom_object_relationship_types' => []
+        }
+      }
+
+      expect(described_class.has_custom_object_requirements?(requirements_hash)).to be(false)
+    end
+
+    it 'should return false when custom requirements empty' do
+      requirements_hash = {
+        'custom_objects' => {}
+      }
+
+      expect(described_class.has_custom_object_requirements?(requirements_hash)).to be(false)
+    end
+
+    it 'should return false when custom requirements are not present' do
+      requirements_hash = {}
+
+      expect(described_class.has_custom_object_requirements?(requirements_hash)).to be(false)
+    end
+
+    it 'should return false when requirements are not present' do
+      requirements_hash = nil
+
+      expect(described_class.has_custom_object_requirements?(requirements_hash)).to be(false)
+    end
+  end
+
   describe 'files' do
     it 'should return all the files within the app folder excluding files in tmp folder' do
       files = %w[app.css app.js assets/logo-small.png assets/logo.png lib/a.js lib/a.txt

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -86,7 +86,7 @@ describe ZendeskAppsSupport::Validations::Requirements do
       requirements_content = {
         custom_objects: {
           custom_object_types: [],
-          custom_object_relationships: []
+          custom_object_relationship_types: []
         }
       }
       25.times do
@@ -96,7 +96,7 @@ describe ZendeskAppsSupport::Validations::Requirements do
         }
       end
       26.times do
-        requirements_content[:custom_objects][:custom_object_relationships] << {
+        requirements_content[:custom_objects][:custom_object_relationship_types] << {
           key: 'foo',
           source: 'bar',
           target: 'baz'


### PR DESCRIPTION
After some discussion with @seangoedecke [here](https://github.com/zendesk/zendesk_app_market/pull/3854#discussion_r352382213) and offline, we decided the best place to put a method to check for custom object requirements is in zas. This adds it, and replaces some hard coded strings with consts.