### PR TITLE
[AF-1919] output installed.json format

### DIFF
--- a/lib/zendesk_apps_support/installed.rb
+++ b/lib/zendesk_apps_support/installed.rb
@@ -12,6 +12,15 @@ module ZendeskAppsSupport
       @installations = installations
     end
 
+    def obj(options = {})
+      {
+        apps: @appsjs,
+        installation_orders: options.fetch(:installation_orders, {}),
+        installations: @installations,
+        rollbar_zaf_access_token: options.fetch(:rollbar_zaf_access_token, '')
+      }
+    end
+
     def compile(options = {})
       INSTALLED_TEMPLATE.result(
         appsjs: @appsjs,

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -139,8 +139,8 @@ module ZendeskAppsSupport
         author: manifest.author,
         framework_version: manifest.framework_version,
         id: app_id,
-        location_icons: location_icons,
-        logo_asset_hash: generate_logo_hash(manifest.products),
+        location_options: manifest.location_options,
+        products: manifest.products,
         name: name,
         version: manifest.version
       }

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -130,12 +130,7 @@ module ZendeskAppsSupport
         raise ArgumentError, e.message
       end
 
-      locale = options.fetch(:locale, 'en')
-
-      source = manifest.iframe_only? ? nil : app_js
       app_class_name = "app-#{app_id}"
-      # if no_template is an array, we still need the templates
-      templates = manifest.no_template == true ? {} : compiled_templates(app_id, asset_url_prefix)
 
       {
         app_class_name: app_class_name,
@@ -144,7 +139,6 @@ module ZendeskAppsSupport
         author: manifest.author,
         framework_version: manifest.framework_version,
         id: app_id,
-        iframe_only: manifest.iframe_only?,
         location_icons: location_icons,
         logo_asset_hash: generate_logo_hash(manifest.products),
         name: name,

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -121,6 +121,37 @@ module ZendeskAppsSupport
       files.select { |f| f =~ %r{^translations/} }
     end
 
+    def obj(options)
+      begin
+        app_id = options.fetch(:app_id)
+        asset_url_prefix = options.fetch(:assets_dir)
+        name = options.fetch(:app_name)
+      rescue KeyError => e
+        raise ArgumentError, e.message
+      end
+
+      locale = options.fetch(:locale, 'en')
+
+      source = manifest.iframe_only? ? nil : app_js
+      app_class_name = "app-#{app_id}"
+      # if no_template is an array, we still need the templates
+      templates = manifest.no_template == true ? {} : compiled_templates(app_id, asset_url_prefix)
+
+      {
+        app_class_name: app_class_name,
+        app_class_properties: manifest.app_class_properties,
+        asset_url_prefix: asset_url_prefix,
+        author: manifest.author,
+        framework_version: manifest.framework_version,
+        id: app_id,
+        iframe_only: manifest.iframe_only?,
+        location_icons: location_icons,
+        logo_asset_hash: generate_logo_hash(manifest.products),
+        name: name,
+        version: manifest.version
+      }
+    end
+
     # this is not really compile_js, it compiles the whole app including scss for v1 apps
     def compile(options)
       begin


### PR DESCRIPTION
### Description

ZAS should output the new `installed.json` format.  This new `installed.json` should also respect separation of concerns:

* ZAS should only be a helper method for ZAM's `CompileInstalledService` and expose raw information from the ZAM database combined with raw information from the manifest on a json object that we will call `installed.json`, and which will be accessible/rendered via the route `/apps/installed.json`.
* Processing of the ZAM database information and manifest metadata from `installed.json` should only occur within ZAF, in the `initInstalledJs` function to be attached to the `ZendeskApps` object.
* This means that a large amount of the existing logic in the `lib/zendesk_apps_support/package.rb` file within ZAS should be ignored when called via the new code path in ZAM within this PR https://github.com/zendesk/zendesk_app_market/pull/3911, as this logic will be ultimately moved to the `initInstalledJs` function in ZAF.

### Todo

- [ ] Add tests
- [ ] Figure out what names things should have
- [ ] Doublecheck all information required is present on metadata objects

### Overall architecture

![IMG_20200130_140105](https://user-images.githubusercontent.com/1825818/73416566-4cf56880-4369-11ea-895b-98009e8a19c9.jpg)

### Context

As part of moving from installed.js -> installed.json, we would like to implement new code in ZendeskAppsSupport (to be used by a new code path in ZAM), that otherwise will not be called by anything else.

For this code to be used, the feature_flag_to_be_decided will need to be turned on in Lotus (restrict to Support only at the outset).

### Risks

Low. Separate codepath / new code only.

### References

* JIRA: https://zendesk.atlassian.net/browse/AF-1919
* https://github.com/zendesk/zendesk_app_market/pull/3911
* [Google Doc](https://docs.google.com/document/d/15pefbQKJ9veZUH95UNrlLuf0qhY_OhUcaCZ6Wuo_Uew/edit#heading=h.ebjpp41tdxhz)