### PR TITLE
Add top_bar location for Zendesk Sell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ matrix:
   include:
     - rvm: 2.4.0
       env: COMMAND=rubocop
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
+  - bundle install
 script:
   - bundle exec $COMMAND
 cache: bundler

--- a/lib/zendesk_apps_support/location.rb
+++ b/lib/zendesk_apps_support/location.rb
@@ -63,7 +63,8 @@ module ZendeskAppsSupport
       Location.new(id: 21, name: 'dashboard', product_code: Product::SELL.code, visible: true),
       Location.new(id: 22, name: 'note_editor', product_code: Product::SELL.code, visible: true),
       Location.new(id: 23, name: 'call_log_editor', product_code: Product::SELL.code, visible: true),
-      Location.new(id: 24, name: 'email_editor', product_code: Product::SELL.code, visible: true)
+      Location.new(id: 24, name: 'email_editor', product_code: Product::SELL.code, visible: true),
+      Location.new(id: 25, name: 'top_bar', product_code: Product::SELL.code, visible: true)
     ].freeze
   end
 end


### PR DESCRIPTION
This change adds `top_bar` location for Sell product. Together with location itself it also adds possibility to set icons for that location (i.e. to change the icon upon a notification).

The changes in the code are straightforward and in-line with what has been already there for Support product.

The tests for icon location have been refactored a bit to have a clearer way of mocking manifest locations differently for different scenarios.

JIRA issues: SELCHA-14, SELCHA-9

cc @zendesk/vegemite 
@zendesk/dingo 