### PR TITLE
[POC] Support to bundle_oauth and bundle_integration_key

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,6 +63,10 @@ en:
             multiple_channel_integrations: Specifying multiple channel integrations
               in requirements.json is not supported.
             too_many_oauth_parameters: "Too many parameters with type 'oauth': one permitted"
+            too_many_bundle_oauth: "Too many parameters with type 'bundle_oauth': one permitted"
+            too_many_bundle_integration_key: "Too many parameters with type 'bundle_integration_key': one permitted"
+            missing_bundle_oauth: "Parameter of type 'bundle_integration_key' exist without 'bundle_oauth'"
+            missing_bundle_integration_key: "Parameter of type 'bundle_oauth' exist without 'bundle_integration_key'"
             invalid_cr_schema_keys:
               one: 'Custom resources schema contains an invalid key: %{invalid_keys}'
               other: 'Custom resources schema contains invalid keys: %{invalid_keys}'

--- a/lib/zendesk_apps_support/manifest/parameter.rb
+++ b/lib/zendesk_apps_support/manifest/parameter.rb
@@ -3,7 +3,7 @@
 module ZendeskAppsSupport
   class Manifest
     class Parameter
-      TYPES = %w[text password checkbox url number multiline hidden oauth].freeze
+      TYPES = %w[text password checkbox url number multiline hidden oauth bundle_oauth bundle_integration_key].freeze
       ATTRIBUTES = %i[name type required secure default].freeze
       attr_reader(*ATTRIBUTES)
       def default?

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -47,6 +47,7 @@ module ZendeskAppsSupport
             errors << invalid_type_error(manifest)
             errors << too_many_oauth_parameters(manifest)
             errors << name_as_parameter_name_error(manifest)
+            errors << invalid_use_of_bundle(manifest)
           end
 
           if manifest.requirements_only? || manifest.marketing_only?
@@ -71,6 +72,21 @@ module ZendeskAppsSupport
             errors << ban_parameters(manifest)
             errors << private_marketing_app_error(manifest)
           end
+        end
+
+        def invalid_use_of_bundle(manifest)
+          errors = []
+          bundle_oauth_parameters = manifest.parameters.select{ |x| x.type == 'bundle_oauth' }
+          bundle_integration_key_parameters = manifest.parameters.select{ |x| x.type == 'bundle_integration_key' }
+
+          errors << ValidationError.new(:too_many_bundle_oauth) if bundle_oauth_parameters.count > 1
+          errors << ValidationError.new(:too_many_bundle_integration_key) if bundle_integration_key_parameters.count > 1
+
+          if bundle_oauth_parameters.count != bundle_integration_key_parameters.count
+            errors << ValidationError.new(:missing_bundle_oauth) if bundle_oauth_parameters.count == 0
+            errors << ValidationError.new(:missing_bundle_integration_key) if bundle_integration_key_parameters.count == 0
+          end
+          errors
         end
 
         def type_checks(manifest)

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -617,5 +617,71 @@ describe ZendeskAppsSupport::Validations::Manifest do
       package = create_package(parameter_hash)
       expect(package).to have_error "Too many parameters with type 'oauth': one permitted"
     end
+
+    context 'bundle' do
+      it 'should have only one bundle_oauth in parameter list' do
+        parameter_hash = {
+          'parameters' =>
+          [
+            {
+              'name' => 'bundle_token',
+              'type' => 'bundle_oauth'
+            },
+            {
+              'name' => 'bundle_token_2',
+              'type' => 'bundle_oauth'
+            },
+          ]
+        }
+        package = create_package(parameter_hash)
+        expect(package).to have_error "Too many parameters with type 'bundle_oauth': one permitted"
+      end
+
+      it 'should have only one bundle_integration_key in parameter list' do
+        parameter_hash = {
+          'parameters' =>
+          [
+            {
+              'name' => 'bundle_integration_key',
+              'type' => 'bundle_integration_key'
+            },
+            {
+              'name' => 'bundle_integration_key_2',
+              'type' => 'bundle_integration_key'
+            },
+          ]
+        }
+        package = create_package(parameter_hash)
+        expect(package).to have_error "Too many parameters with type 'bundle_integration_key': one permitted"
+      end
+
+      it 'should have a bundle_oauth if a bundle_integration_key exist' do
+        parameter_hash = {
+          'parameters' =>
+          [
+            {
+              'name' => 'bundle_integration_key',
+              'type' => 'bundle_integration_key'
+            },
+          ]
+        }
+        package = create_package(parameter_hash)
+        expect(package).to have_error "Parameter of type 'bundle_integration_key' exist without 'bundle_oauth'"
+      end
+
+      it 'should have a bundle_oauth if a bundle_oauth exist' do
+        parameter_hash = {
+          'parameters' =>
+          [
+            {
+              'name' => 'bundle_token',
+              'type' => 'bundle_oauth'
+            },
+          ]
+        }
+        package = create_package(parameter_hash)
+        expect(package).to have_error "Parameter of type 'bundle_oauth' exist without 'bundle_integration_key'"
+      end
+    end
   end
 end


### PR DESCRIPTION
### Description

Install App

In order to utilise the external OAuth Client created here, changes need to be made in ZAM.

The flow we are striving to achieve is as follows
![image](https://user-images.githubusercontent.com/26154804/75212423-0154a400-57db-11ea-8b44-135b3f6b11d6.png)


### CHANGES TO ZAS

Since we are dependent on an OAuthClient generated outside of ZAM, changes need to be made to the app manifest.json file to enable the app to make use of it. The plan is to create two new custom hidden fields like the following 

```
"parameters": [
  {
    "name": "bundle_token",
    "type": "bundle_oauth"
  },
  {
    "name": "bundle_integration_key",
    "type": "bundle_integration_key"
  }
]
```

###Features

* Both must exist together
* Both fields are hidden
* `bundle_oauth`
** This field will store the connection_uuid like the pre-existing `oauth` type
* `bundle_integration_key`
** This field will store the integration key which is specified during the ZIS-Bundle upload (removing the need to rely on procedurally generated versions from ZAM)

Currently, if we rely on the OAuthClient generated in ZAM, the flow sequence looks something like this:
![image](https://user-images.githubusercontent.com/26154804/75212558-6b6d4900-57db-11ea-8ece-d33774aed4da.png)

With these changes, ZAP will need some underlying logic to recognise the existence of both of these parameter types and utilise their values to access ZIS-Connections for the `access_token`. This eliminates the need to query ZAM for the `integration_key`
![image](https://user-images.githubusercontent.com/26154804/75212449-17626480-57db-11ea-913d-591eb461fd88.png)

DONE WHEN

- [x] ZAS is able to validate both `bundle_oauth` and `bundle_integration_key`
- [x] Translations are ignored in this POC