### PR TITLE
[VEGEMITE-312] The (old) ruby is deprecated, long live the new ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ language: ruby
 sudo: false
 dist: trusty
 rvm:
+  - 2.6.0
+  - 2.5.0
   - 2.4.0
   - 2.3.3
-  - 2.2.6
-  - 2.1
 branches:
   only: [master]
 env:


### PR DESCRIPTION
🐕

/cc @zendesk/dingo

### Description
Drop support for ruby 2.1 and 2.2, in preparation for merging the dependabot PR which bumps nokogiri to a more secure version.  Note though that bumping nokogiri requires that we drop 2.1 and 2.2, hence this change.

More context: A customer has asked for us to bump nokogiri per said dependabot change in order to address a security concern they have: https://support.zendesk.com/agent/tickets/5609005

Adds support for ruby 2.5 and ruby 2.6.

### References
* See [this slack thread](https://zendesk.slack.com/archives/C1230V1CG/p1594681052320700) and this dependabot PR: https://github.com/zendesk/zendesk_apps_support/pull/259 .
* [Zendesk Support ticket regarding nokogiri security issue and need to bump said dependency](https://support.zendesk.com/agent/tickets/5609005)
* https://zendesk.atlassian.net/browse/VEGEMITE-312

### Risks
* [RUNTIME] Can this change affect apps rendering for a user?
* Medium. Risk of dropping support for ZAT for people who use older versions of ruby as critical part of their workflow.
