### PR TITLE
[APPS-5335]Update sassc

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       nokogiri (>= 1.8.5, < 1.11.0)
       rb-inotify (= 0.9.10)
       sass
-      sassc (~> 1.11.2)
+      sassc
 
 GEM
   remote: https://rubygems.org/
@@ -25,7 +25,7 @@ GEM
     erubis (2.7.0)
     faker (1.6.6)
       i18n (~> 0.5)
-    ffi (1.9.25)
+    ffi (1.13.1)
     i18n (0.7.0)
     image_size (2.0.2)
     ipaddress_2 (0.13.0)
@@ -73,10 +73,8 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sassc (1.11.4)
-      bundler
-      ffi (~> 1.9.6)
-      sass (>= 3.3.0)
+    sassc (2.4.0)
+      ffi (~> 1.9)
     unicode-display_width (1.3.0)
 
 PLATFORMS
@@ -84,7 +82,7 @@ PLATFORMS
 
 DEPENDENCIES
   bump (~> 0.5.1)
-  bundler (= 1.17.3)
+  bundler (= 2.1.4)
   byebug (~> 9.0.6)
   faker (~> 1.6.6)
   rspec (~> 3.4.0)
@@ -92,4 +90,4 @@ DEPENDENCIES
   zendesk_apps_support!
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,4 +90,4 @@ DEPENDENCIES
   zendesk_apps_support!
 
 BUNDLED WITH
-   2.1.4
+   1.17.3

--- a/lib/zendesk_apps_support/sass_functions.rb
+++ b/lib/zendesk_apps_support/sass_functions.rb
@@ -26,9 +26,9 @@ require 'sassc'
 module SassC::Script::Functions
   module AppAssetUrl
     def app_asset_url(name)
-      raise ArgumentError, "Expected #{name} to be a string" unless name.is_a? Sass::Script::Value::String
+      raise ArgumentError, "Expected #{name} to be a string" unless name.is_a? SassC::Script::Value::String
       result = %{url("#{app_asset_url_helper(name)}")}
-      SassC::Script::String.new(result)
+      SassC::Script::Value::String.new(result)
     end
 
     private

--- a/zendesk_apps_support.gemspec
+++ b/zendesk_apps_support.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
 
   s.add_runtime_dependency 'i18n'
-  s.add_runtime_dependency 'sassc', '~> 1.11.2'
+  s.add_runtime_dependency 'sassc'
   s.add_runtime_dependency 'sass' # remove explicit dependency when all compilation uses SassC
   s.add_runtime_dependency 'json'
   s.add_runtime_dependency 'image_size', '~> 2.0.2'
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'faker', '~> 1.6.6'
   s.add_development_dependency 'rubocop', '~> 0.49.0'
   s.add_development_dependency 'byebug', '~> 9.0.6'
-  s.add_development_dependency 'bundler', '1.17.3'
+  s.add_development_dependency 'bundler', '2.1.4'
 
   s.files = Dir.glob('{lib,config}/**/*') + %w[README.md LICENSE]
 end


### PR DESCRIPTION
💐

/cc @zendesk/wattle

### Description
As a part of upgrading rails 5.2.0, we have some gem dependency conflicts.
To resolve this, we need to update sassc to 2.0

```Bundler could not find compatible versions for gem "sassc":
  In Gemfile:
    administrate (~> 0.14.0) was resolved to 0.14.0, which depends on
      sassc-rails (~> 2.1) was resolved to 2.1.2, which depends on
        sassc (>= 2.0)

    zendesk_apps_support (>= 4.29.4) was resolved to 4.29.5, which depends on
      sassc (~> 1.11.2)
```
### References
https://zendesk.atlassian.net/browse/APPS-5335

#### Before merging this PR
- [ ] Fill out the Risks section
- [ ] Think about performance and security issues

### Risks
* [RUNTIME] No
* [Medium] Sassc gem bump 
