### PR TITLE
Switch back to 1.17.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ PLATFORMS
 
 DEPENDENCIES
   bump (~> 0.5.1)
-  bundler (= 2.1.4)
+  bundler (= 1.17.3)
   byebug (~> 9.0.6)
   faker (~> 1.6.6)
   rspec (~> 3.4.0)

--- a/zendesk_apps_support.gemspec
+++ b/zendesk_apps_support.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'faker', '~> 1.6.6'
   s.add_development_dependency 'rubocop', '~> 0.49.0'
   s.add_development_dependency 'byebug', '~> 9.0.6'
-  s.add_development_dependency 'bundler', '2.1.4'
+  s.add_development_dependency 'bundler', '1.17.3'
 
   s.files = Dir.glob('{lib,config}/**/*') + %w[README.md LICENSE]
 end


### PR DESCRIPTION
🐕

/cc @zendesk/dingo

### Description

We accidentally switched to the latest Bundler when bumping gems. This rolls this back.

### Risks
None.