### PR TITLE
[DINGO-1372] Add strings for new warning validation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -123,6 +123,9 @@ en:
                 do not match products in translations (%{translation_products})
               insecure_token_parameter_in_manifest: 'Make sure to set secure to true
                 when using keys in Settings. Learn more: %{link}'
+              default_secure_or_hidden_parameter_in_manifest: Default values for secure
+                or hidden parameters are not stored securely. Be sure to review them
+                and confirm they do not contain sensitive data
             stylesheet_error: 'Sass error: %{sass_error}'
             invalid_type_parameter:
               one: "%{invalid_types} is an invalid parameter type."

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -355,6 +355,7 @@ parts:
       key: "txt.apps.admin.error.app_build.translation.default_secure_or_hidden_parameter_in_manifest"
       title: "Validation message to indicate that a hidden or secure manifest parameter has a default value. Do not translate 'secure' and 'hidden'. Secure(true) in manifest refers to https://developer.zendesk.com/apps/docs/developer-guide/using_sdk#using-secure-settings"
       value: "Default values for secure or hidden parameters are not stored securely. Be sure to review them and confirm they do not contain sensitive data"
+      screenshot: "https://drive.google.com/file/d/1MI6ci6Jz6xtwOXjcbHFCfNi1FjXKOuv9/view?usp=sharing"
   - translation:
       key: "txt.apps.admin.error.app_build.stylesheet_error"
       title: "App builder job: invalid stylesheet syntax"

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -352,6 +352,10 @@ parts:
       value: "Make sure to set secure to true when using keys in Settings. Learn more: %{link}"
       screenshot: "https://drive.google.com/open?id=1ss3nNN2RG29R7StjCtiH8qjuwFBlRApJ"
   - translation:
+      key: "txt.apps.admin.error.app_build.translation.default_secure_or_hidden_parameter_in_manifest"
+      title: "Validation message to indicate that a hidden or secure manifest parameter has a default value. Do not translate 'secure' and 'hidden'. Secure(true) in manifest refers to https://developer.zendesk.com/apps/docs/developer-guide/using_sdk#using-secure-settings"
+      value: "Default values for secure or hidden parameters are not stored securely. Be sure to review them and confirm they do not contain sensitive data"
+  - translation:
       key: "txt.apps.admin.error.app_build.stylesheet_error"
       title: "App builder job: invalid stylesheet syntax"
       value: "Sass error: %{sass_error}"


### PR DESCRIPTION
🐕

/cc @zendesk/dingo

### Description

Adds strings for new warning about default settings for secure/hidden params.

@zendesk/localization

### References
https://zendesk.atlassian.net/browse/DINGO-1372

#### Before merging this PR
- [ ] Fill out the Risks section
- [ ] Think about performance and security issues

### Risks
* [RUNTIME] Can this change affect apps rendering for a user? No
* None: just a string