### PR TITLE
[DINGO-1372] Add warning for sensitive data in hidden fields

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       ipaddress_2 (~> 0.13.0)
       json
       loofah (~> 2.3.1)
-      marcel (~> 1.0.1)
+      marcel
       nokogiri (>= 1.8.5, < 1.11.0)
       rb-inotify (= 0.9.10)
       sass

--- a/lib/zendesk_apps_support/validations/mime.rb
+++ b/lib/zendesk_apps_support/validations/mime.rb
@@ -21,7 +21,7 @@ module ZendeskAppsSupport
 
         def block_listed?(app_file)
           mime_type = Marcel::MimeType.for(StringIO.new(app_file.read))
-          content_subtype = Marcel::Magic.new(mime_type).subtype if mime_type
+          content_subtype = mime_type.split('/', 2).last if mime_type
           extension_name = app_file.extension.delete('.')
 
           ([content_subtype, extension_name] & UNSUPPORTED_MIME_TYPES).any?

--- a/lib/zendesk_apps_support/validations/secure_settings.rb
+++ b/lib/zendesk_apps_support/validations/secure_settings.rb
@@ -31,7 +31,7 @@ module ZendeskAppsSupport
           parameter_type == 'text' || parameter_type == 'password'
         end
 
-        def secure_settings_warning
+        def hidden_default_parameter_warning
           I18n.t(
             'txt.apps.admin.error.app_build.translation.default_secure_or_hidden_parameter_in_manifest'
           )

--- a/lib/zendesk_apps_support/validations/secure_settings.rb
+++ b/lib/zendesk_apps_support/validations/secure_settings.rb
@@ -11,11 +11,17 @@ module ZendeskAppsSupport
           manifest_params = package.manifest.parameters
 
           insecure_params_found = manifest_params.any? { |param| insecure_param?(param) }
-
           package.warnings << secure_settings_warning if insecure_params_found
+
+          secure_or_hidden_default_param_found = manifest_params.any? { |param| secure_or_hidden_default_param?(param) }
+          package.warnings << hidden_default_parameter_warning if secure_or_hidden_default_param_found
         end
 
         private
+
+        def secure_or_hidden_default_param?(parameter)
+          parameter.default? && (parameter.secure || parameter.type == 'hidden')
+        end
 
         def insecure_param?(parameter)
           parameter.name =~ SECURABLE_KEYWORDS_REGEXP && type_password_or_text?(parameter.type) && !parameter.secure
@@ -23,6 +29,12 @@ module ZendeskAppsSupport
 
         def type_password_or_text?(parameter_type)
           parameter_type == 'text' || parameter_type == 'password'
+        end
+
+        def secure_settings_warning
+          I18n.t(
+            'txt.apps.admin.error.app_build.translation.default_secure_or_hidden_parameter_in_manifest'
+          )
         end
 
         def secure_settings_warning

--- a/spec/validations/secure_settings_spec.rb
+++ b/spec/validations/secure_settings_spec.rb
@@ -8,8 +8,16 @@ describe ZendeskAppsSupport::Validations::SecureSettings do
   let(:insecure_param) { ZendeskAppsSupport::Manifest::Parameter.new('name' => 'my_token') }
   let(:regular_param)  { ZendeskAppsSupport::Manifest::Parameter.new('name' => 'subdomain') }
   let(:regular_default_param)  { ZendeskAppsSupport::Manifest::Parameter.new('name' => 'subdomain', 'default' => true) }
-  let(:secured_default_param)  { ZendeskAppsSupport::Manifest::Parameter.new('name' => 'subdomain', 'secure' => true, 'default' => true) }
-  let(:hidden_default_param)  { ZendeskAppsSupport::Manifest::Parameter.new('name' => 'subdomain', 'type' => 'hidden', 'default' => true) }
+  let(:secured_default_param)  do
+    ZendeskAppsSupport::Manifest::Parameter.new('name' => 'subdomain',
+                                                'secure' => true,
+                                                'default' => true)
+  end
+  let(:hidden_default_param) do
+    ZendeskAppsSupport::Manifest::Parameter.new('name' => 'subdomain',
+                                                'type' => 'hidden',
+                                                'default' => true)
+  end
 
   context 'when default manifest parameters are not secure or hidden' do
     it 'returns no warning' do

--- a/spec/validations/secure_settings_spec.rb
+++ b/spec/validations/secure_settings_spec.rb
@@ -7,6 +7,38 @@ describe ZendeskAppsSupport::Validations::SecureSettings do
   let(:secured_param)  { ZendeskAppsSupport::Manifest::Parameter.new('name' => 'my_token', 'secure' => true) }
   let(:insecure_param) { ZendeskAppsSupport::Manifest::Parameter.new('name' => 'my_token') }
   let(:regular_param)  { ZendeskAppsSupport::Manifest::Parameter.new('name' => 'subdomain') }
+  let(:regular_default_param)  { ZendeskAppsSupport::Manifest::Parameter.new('name' => 'subdomain', 'default' => true) }
+  let(:secured_default_param)  { ZendeskAppsSupport::Manifest::Parameter.new('name' => 'subdomain', 'secure' => true, 'default' => true) }
+  let(:hidden_default_param)  { ZendeskAppsSupport::Manifest::Parameter.new('name' => 'subdomain', 'type' => 'hidden', 'default' => true) }
+
+  context 'when default manifest parameters are not secure or hidden' do
+    it 'returns no warning' do
+      allow(package).to receive_message_chain('manifest.parameters') { [regular_param, regular_default_param] }
+      subject.call(package)
+
+      expect(package.warnings).to be_empty
+    end
+  end
+
+  context 'when default manifest parameters are secure' do
+    it 'returns a warning' do
+      allow(package).to receive_message_chain('manifest.parameters') { [secured_default_param] }
+      subject.call(package)
+
+      expect(package.warnings.size).to eq(1)
+      expect(package.warnings[0]).to include('confirm they do not contain sensitive data')
+    end
+  end
+
+  context 'when default manifest parameters are hidden' do
+    it 'returns a warning' do
+      allow(package).to receive_message_chain('manifest.parameters') { [hidden_default_param] }
+      subject.call(package)
+
+      expect(package.warnings.size).to eq(1)
+      expect(package.warnings[0]).to include('confirm they do not contain sensitive data')
+    end
+  end
 
   context 'when manifest parameters do not contain SECURABLE_KEYWORDS' do
     it 'returns no warning' do

--- a/zendesk_apps_support.gemspec
+++ b/zendesk_apps_support.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'loofah', '~> 2.3.1'
   s.add_runtime_dependency 'nokogiri', '>= 1.8.5', '< 1.11.0'
   s.add_runtime_dependency 'rb-inotify', '0.9.10'
-  s.add_runtime_dependency 'marcel', '~> 1.0.1'
+  s.add_runtime_dependency 'marcel'
   s.add_runtime_dependency 'ipaddress_2', '~> 0.13.0'
   s.add_development_dependency 'rspec', '~> 3.4.0'
   s.add_development_dependency 'bump', '~> 0.5.1'


### PR DESCRIPTION
🐕


### Description

This PR adds a new validation for default parameter values - if the param is hidden or secure, we warn the developer that they shouldn't store secrets in the defaults.

We can't use `Marcel::Magic` without defacto pinning `marcel` to v1+, so we need to do the `split('/')` logic ourselves.

### References
https://zendesk.atlassian.net/browse/DINGO-1372

#### Before merging this PR
- [ ] Fill out the Risks section
- [ ] Think about performance and security issues

### Risks
* [RUNTIME] Can this change affect apps rendering for a user? No
* Low: apps fail to upload