### PR TITLE
[VEG-599] Bump the version of the gem. Bump bundler to 2.2.26

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_support (4.29.8)
+    zendesk_apps_support (4.29.9)
       erubis
       i18n
       image_size (~> 2.0.2)
@@ -26,7 +26,7 @@ GEM
     erubis (2.7.0)
     faker (1.6.6)
       i18n (~> 0.5)
-    ffi (1.15.0)
+    ffi (1.15.3)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     image_size (2.0.2)
@@ -84,7 +84,7 @@ PLATFORMS
 
 DEPENDENCIES
   bump (~> 0.5.1)
-  bundler (= 1.17.3)
+  bundler (= 2.2.26)
   byebug (~> 9.0.6)
   faker (~> 1.6.6)
   parallel (= 1.12.1)
@@ -93,4 +93,4 @@ DEPENDENCIES
   zendesk_apps_support!
 
 BUNDLED WITH
-   2.2.24
+   2.2.26

--- a/zendesk_apps_support.gemspec
+++ b/zendesk_apps_support.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'zendesk_apps_support'
-  s.version     = '4.29.8'
+  s.version     = '4.29.9'
   s.license     = 'Apache License Version 2.0'
   s.authors     = ['James A. Rosen', 'Likun Liu', 'Sean Caffery', 'Daniel Ribeiro']
   s.email       = ['dev@zendesk.com']
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'faker', '~> 1.6.6'
   s.add_development_dependency 'rubocop', '~> 0.49.0'
   s.add_development_dependency 'byebug', '~> 9.0.6'
-  s.add_development_dependency 'bundler', '1.17.3'
+  s.add_development_dependency 'bundler', '2.2.26'
   s.add_development_dependency 'parallel', '1.12.1'
 
   s.files = Dir.glob('{lib,config}/**/*') + %w[README.md LICENSE]


### PR DESCRIPTION
🐕

/cc @zendesk/dingo @zendesk/vegemite 

### Description

* Bumps the version of the gem so that we can use the new shiny validation for "flexible": true.
* Bumps bundler to a modern shiny version.

### References
[VEG-599](https://zendesk.atlassian.net/browse/VEG-599)

#### Before merging this PR
- [x] Fill out the Risks section
- [x] Think about performance and security issues

### Risks
* [RUNTIME] Can this change affect apps rendering for a user? No, version bump only.
* [Low] Change to bundler version might break other gems and systems that use this.
