### PR TITLE
[DINGO-1662] Add validation for webhook keys

### DIFF
--- a/lib/zendesk_apps_support/app_requirement.rb
+++ b/lib/zendesk_apps_support/app_requirement.rb
@@ -2,6 +2,7 @@
 
 module ZendeskAppsSupport
   class AppRequirement
+    WEBHOOKS_KEY = 'webhooks'
     CUSTOM_OBJECTS_KEY = 'custom_objects'
     CUSTOM_OBJECTS_TYPE_KEY = 'custom_object_types'
     CUSTOM_OBJECTS_RELATIONSHIP_TYPE_KEY = 'custom_object_relationship_types'

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -29,6 +29,7 @@ module ZendeskAppsSupport
             errors << invalid_channel_integrations(requirements)
             errors << invalid_custom_fields(requirements)
             errors << invalid_custom_objects(requirements)
+            errors << invalid_webhooks(requirements)
             errors << missing_required_fields(requirements)
             errors.flatten!
             errors.compact!
@@ -104,6 +105,26 @@ module ZendeskAppsSupport
                                             field: 'manifest_url',
                                             identifier: identifier)
             end
+          end
+        end
+
+        def invalid_webhooks(requirements)
+          webhook_requirements = requirements[AppRequirement::WEBHOOKS_KEY]
+
+          return if webhook_requirements.nil?
+
+          validate_webhook_keys(webhook_requirements)
+        end
+
+        def validate_webhook_keys(webhook_requirements)
+          required_keys = %w[name status endpoint http_method request_format]
+
+          missing_keys = required_keys - webhook_requirements.keys
+
+          missing_keys.map do |key|
+            ValidationError.new(:missing_required_fields,
+                                field: key,
+                                identifier: AppRequirement::WEBHOOKS_KEY)
           end
         end
 

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -272,4 +272,42 @@ describe ZendeskAppsSupport::Validations::Requirements do
       end
     end
   end
+
+  context 'webhooks requirements validations' do
+    context 'there is a valid webhooks schema defined' do
+      let(:requirements_string) do
+        JSON.generate(
+          'webhooks' => {
+            'name' => 'Example',
+            'status' => 'active',
+            'endpoint' => 'https://example.com',
+            'http_method' => 'POST',
+            'request_format' => 'json',
+          }
+        )
+      end
+
+      it 'does not return an error' do
+        expect(errors).to be_empty
+      end
+    end
+
+    context 'a webhooks schema is missing required keys' do
+      let(:requirements_string) do
+        JSON.generate(
+          'webhooks' => {
+          }
+        )
+      end
+      let(:required_keys) { [ 'name', 'status', 'endpoint', 'http_method', 'request_format' ] }
+
+      it 'creates an error' do
+        errors.each do |error|
+          expect(error.key).to eq(:missing_required_fields)
+          expect(required_keys).to include(error.data[:field])
+        end
+        expect(errors.count).to eq(required_keys.count)
+      end
+    end
+  end
 end


### PR DESCRIPTION
🐕

/cc @zendesk/dingo

### Description

Adds required key validations for webhooks. This is mostly based on what is currently done for custom object key validation.

### References
https://zendesk.atlassian.net/browse/DINGO-1662

### Risks
* [RUNTIME] Can this change affect apps rendering for a user? No
* [low] Incorrectly validates webhooks, causing app validation to fail.
