### PR TITLE
[DINGO-1662] Bump version from 4.30.1 to 4.31.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_support (4.30.1)
+    zendesk_apps_support (4.31.0)
       erubis
       i18n
       image_size (~> 2.0.2)

--- a/zendesk_apps_support.gemspec
+++ b/zendesk_apps_support.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'zendesk_apps_support'
-  s.version     = '4.30.1'
+  s.version     = '4.31.0'
   s.license     = 'Apache License Version 2.0'
   s.authors     = ['James A. Rosen', 'Likun Liu', 'Sean Caffery', 'Daniel Ribeiro']
   s.email       = ['dev@zendesk.com']


### PR DESCRIPTION
🐕

/cc @zendesk/dingo @zendesk/vegemite 

### Description

Bumps version to include https://github.com/zendesk/zendesk_apps_support/pull/319.

### References
https://zendesk.atlassian.net/browse/DINGO-1662

### Risks
* [RUNTIME] Can this change affect apps rendering for a user? No
* [low] Webhook validation is incorrect for apps
