### PR TITLE
[DINGO-1662] Handle correct webhook requirement structure

### DIFF
--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -113,18 +113,20 @@ module ZendeskAppsSupport
 
           return if webhook_requirements.nil?
 
-          validate_webhook_keys(webhook_requirements)
+          webhook_requirements.map do |identifier, requirement|
+            validate_webhook_keys(identifier, requirement)
+          end.flatten
         end
 
-        def validate_webhook_keys(webhook_requirements)
+        def validate_webhook_keys(identifier, requirement)
           required_keys = %w[name status endpoint http_method request_format]
 
-          missing_keys = required_keys - webhook_requirements.keys
+          missing_keys = required_keys - requirement.keys
 
           missing_keys.map do |key|
             ValidationError.new(:missing_required_fields,
                                 field: key,
-                                identifier: AppRequirement::WEBHOOKS_KEY)
+                                identifier: identifier)
           end
         end
 

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -278,11 +278,13 @@ describe ZendeskAppsSupport::Validations::Requirements do
       let(:requirements_string) do
         JSON.generate(
           'webhooks' => {
-            'name' => 'Example',
-            'status' => 'active',
-            'endpoint' => 'https://example.com',
-            'http_method' => 'POST',
-            'request_format' => 'json',
+            'my_webhook' => {
+              'name' => 'Example',
+              'status' => 'active',
+              'endpoint' => 'https://example.com',
+              'http_method' => 'POST',
+              'request_format' => 'json',
+            }
           }
         )
       end
@@ -296,6 +298,7 @@ describe ZendeskAppsSupport::Validations::Requirements do
       let(:requirements_string) do
         JSON.generate(
           'webhooks' => {
+            'my_webhook': {}
           }
         )
       end
@@ -307,6 +310,26 @@ describe ZendeskAppsSupport::Validations::Requirements do
           expect(required_keys).to include(error.data[:field])
         end
         expect(errors.count).to eq(required_keys.count)
+      end
+    end
+
+    context 'multiple webhooks schemas are missing required keys' do
+      let(:requirements_string) do
+        JSON.generate(
+          'webhooks' => {
+            'my_webhook': {},
+            'my_other_webhook': {}
+          }
+        )
+      end
+      let(:required_keys) { [ 'name', 'status', 'endpoint', 'http_method', 'request_format' ] }
+
+      it 'creates an error' do
+        errors.each do |error|
+          expect(error.key).to eq(:missing_required_fields)
+          expect(required_keys).to include(error.data[:field])
+        end
+        expect(errors.count).to eq(required_keys.count * 2)
       end
     end
   end


### PR DESCRIPTION
🐕

/cc @zendesk/dingo @zendesk/vegemite 

### Description

My [previous PR](https://github.com/zendesk/zendesk_apps_support/pull/319) added required key validation to webhook requirements in the following format:

```
{
  webhooks: {
    name: 'my webhook',
    endpoint: 'https://foo.com/bar',
    ...etc
  }
}
```

However we expect user to provide webhooks in the following structure:

```
{
  webhooks: {
    my_webhook_identifier: {
      name: 'my webhook',
      endpoint: 'https://foo.com/bar',
      ...etc
    }
  }
}
```

This updates the validation to handle the correct format, and adds an extra test for when multiple webhooks are specified.

### References
https://zendesk.atlassian.net/browse/DINGO-1662

### Risks
* [RUNTIME] Can this change affect apps rendering for a user? No
* [low] Webhook validation is broken in some other way
