### PR TITLE
[DINGO-1723] Add url validation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,6 +148,7 @@ en:
               other: "%{invalid_locations} are invalid locations in framework v1."
             oauth_parameter_cannot_be_secure: oauth parameter cannot be set to be
               secure.
+            invalid_url: '%{field} must be a valid URL, got "%{value}".'
         warning:
           app_build:
             deprecated_version: You are targeting a deprecated version of the framework.

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -412,3 +412,7 @@ parts:
       key: "txt.apps.admin.error.app_build.oauth_parameter_cannot_be_secure"
       title: "oauth parameter cannot be set to be secure."
       value: "oauth parameter cannot be set to be secure."
+  - translation:
+      key: "txt.apps.admin.error.app_build.invalid_url"
+      title: "App builder job: this value needs to be a valid URL, but something else was passed in. placeholder value is taken from user input. You can translate as: The value %{field} must be a valid URL... to avoid any gender issues."
+      value: "%{field} must be a valid URL, got \"%{value}\"."

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -431,9 +431,14 @@ module ZendeskAppsSupport
         end
 
         def validate_url(value, label_for_error)
-          unless value.nil? || value.match(/^https?:\/\//)
+          return if value.nil?
+
+          uri = URI.parse(value)
+          unless uri.is_a?(URI::HTTP) && !uri.host.nil?
             ValidationError.new(:invalid_url, field: label_for_error, value: value)
           end
+        rescue URI::InvalidURIError
+          ValidationError.new(:invalid_url, field: label_for_error, value: value)
         end
       end
     end

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -66,12 +66,14 @@ module ZendeskAppsSupport
 
         def validate_urls(manifest)
           errors = []
-          if manifest.terms_conditions_url
-            errors << validate_url(manifest.terms_conditions_url, "terms_conditions_url")
+
+          if manifest.terms_conditions_url && !valid_url?(manifest.terms_conditions_url)
+            errors << ValidationError.new(:invalid_url, field: 'terms_conditions_url', value: manifest.terms_conditions_url)
           end
 
-          if manifest.author
-            errors << validate_url(manifest.author["url"], "author url")
+          author = manifest.author
+          if author && author["url"] && !valid_url?(author["url"])
+            errors << ValidationError.new(:invalid_url, field: 'author url', value: author["url"])
           end
           errors
         end
@@ -430,15 +432,11 @@ module ZendeskAppsSupport
           end
         end
 
-        def validate_url(value, label_for_error)
-          return if value.nil?
-
+        def valid_url?(value)
           uri = URI.parse(value)
-          unless uri.is_a?(URI::HTTP) && !uri.host.nil?
-            ValidationError.new(:invalid_url, field: label_for_error, value: value)
-          end
+          uri.is_a?(URI::HTTP) && !uri.host.nil?
         rescue URI::InvalidURIError
-          ValidationError.new(:invalid_url, field: label_for_error, value: value)
+          false
         end
       end
     end

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -692,4 +692,55 @@ describe ZendeskAppsSupport::Validations::Manifest do
       expect(package).to have_error 'oauth parameter cannot be set to be secure.'
     end
   end
+
+  context 'url is not HTTP or HTTPS' do
+    before do
+      @manifest_hash = {
+        'termsConditionsURL' => 'javascript:alert("terms_conditions_url")',
+        'author' => { 'url' => 'javascript:alert("author_url")' }
+      }
+    end
+
+    it 'terms_conditions_url should have an error' do
+      expect(@package).to have_error(/terms_conditions_url must be a valid URL/)
+    end
+
+    it 'author.url should have an error' do
+      expect(@package).to have_error(/author url must be a valid URL/)
+    end
+  end
+
+  context 'url is HTTP' do
+    before do
+      @manifest_hash = {
+        'terms_conditions_url' => 'http://mysite.com/terms_conditions_url',
+        'author' => { 'url' => 'http://mysite.com/author_url' }
+      }
+    end
+
+    it 'terms_conditions_url should not have an error' do
+      expect(@package).not_to have_error(/terms_conditions_url must be a valid URL/)
+    end
+
+    it 'author.url should not have an error' do
+      expect(@package).not_to have_error(/author url must be a valid URL/)
+    end
+  end
+
+  context 'url is HTTPS' do
+    before do
+      @manifest_hash = {
+        'terms_conditions_url' => 'https://mysite.com/terms_conditions_url',
+        'author' => { 'url' => 'https://mysite.com/author_url' }
+      }
+    end
+
+    it 'terms_conditions_url should not have an error' do
+      expect(@package).not_to have_error(/terms_conditions_url must be a valid URL/)
+    end
+
+    it 'author.url should not have an error' do
+      expect(@package).not_to have_error(/author url must be a valid URL/)
+    end
+  end
 end

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -702,11 +702,44 @@ describe ZendeskAppsSupport::Validations::Manifest do
     end
 
     it 'terms_conditions_url should have an error' do
-      expect(@package).to have_error(/terms_conditions_url must be a valid URL/)
+      expect(@package).to have_error("terms_conditions_url must be a valid URL, got \"javascript:alert(\"terms_conditions_url\")\".")
     end
 
     it 'author.url should have an error' do
-      expect(@package).to have_error(/author url must be a valid URL/)
+      expect(@package).to have_error("author url must be a valid URL, got \"javascript:alert(\"author_url\")\".")
+    end
+  end
+
+  context 'url is empty' do
+    before do
+      @manifest_hash = {
+        'termsConditionsURL' => '',
+        'author' => { 'url' => '' }
+      }
+    end
+
+    it 'terms_conditions_url should have an error' do
+      expect(@package).to have_error('terms_conditions_url must be a valid URL, got "".')
+    end
+
+    it 'author.url should have an error' do
+      expect(@package).to have_error('author url must be a valid URL, got "".')
+    end
+  end
+
+  context 'url is nil' do
+    before do
+      @manifest_hash = {
+        'author' => { 'name' => 'author name' }
+      }
+    end
+
+    it 'terms_conditions_url should not have an error' do
+      expect(@package).not_to have_error(/terms_conditions_url must be a valid URL/)
+    end
+
+    it 'author.url should not have an error' do
+      expect(@package).not_to have_error(/author url must be a valid URL/)
     end
   end
 


### PR DESCRIPTION
🐕

/cc @zendesk/dingo

### Description
A private app (and potentially any marketplace app) can contain JavaScript in the manifest.json file which gets executed from the {subdomain}.zendesk.com domain.

STEPS TO REPRODUCE
1. Update the url field in an app in the manifest.json file to "url": "javascript:alert(document.domain)"
2. Package the app and Upload the private App to your account.
3. One the app is installed, click on the App and as the url field is populated, you will see an option to click on the "developer website" link.
4. Click on the link and the javascript will trigger the alert within the context of the accounts subdomain.

An attacker can use this vulnerability to construct a request that, if issued by another application user, will cause JavaScript code supplied by the attacker to execute within the user's browser in the context of that user's session with the application, steal user's cookies, etc.

### References
https://zendesk.atlassian.net/browse/DINGO-1723

### Risks
* [low] validate url
