### PR TITLE
[APPS-5975] Remove rollbarAccessToken when rendering installed.js

### DIFF
--- a/lib/zendesk_apps_support/assets/installed.js.erb
+++ b/lib/zendesk_apps_support/assets/installed.js.erb
@@ -14,8 +14,4 @@
   <% end %>
 }());
 
-<% unless rollbar_zaf_access_token.empty? %>
-ZendeskApps.rollbarAccessToken = "<%= rollbar_zaf_access_token %>";
-<% end %>
-
 ZendeskApps.trigger && ZendeskApps.trigger('ready');

--- a/lib/zendesk_apps_support/installed.rb
+++ b/lib/zendesk_apps_support/installed.rb
@@ -16,8 +16,7 @@ module ZendeskAppsSupport
       INSTALLED_TEMPLATE.result(
         appsjs: @appsjs,
         installations: @installations,
-        installation_orders: options.fetch(:installation_orders, {}),
-        rollbar_zaf_access_token: options.fetch(:rollbar_zaf_access_token, '')
+        installation_orders: options.fetch(:installation_orders, {})
       )
     end
 

--- a/spec/fixtures/installed.js
+++ b/spec/fixtures/installed.js
@@ -61,6 +61,4 @@
 
 }());
 
-ZendeskApps.rollbarAccessToken = "test token";
-
 ZendeskApps.trigger && ZendeskApps.trigger('ready');

--- a/spec/installed_spec.rb
+++ b/spec/installed_spec.rb
@@ -10,8 +10,7 @@ describe ZendeskAppsSupport::Installed do
 
   describe 'compile' do
     it 'should render installed.js' do
-      installedjs = @installed.compile(installation_orders: {},
-                                       rollbar_zaf_access_token: 'test token')
+      installedjs = @installed.compile(installation_orders: {})
 
       expected_installedjs = File.read('spec/fixtures/installed.js')
       expect(installedjs.gsub(/\s+/, ' ')).to eq(expected_installedjs.gsub(/\s+/, ' '))


### PR DESCRIPTION
Rollbar integration has been shutdown, so this became dead code.


🐕

/cc @zendesk/dingo

### Description

### References
Link to a JIRA or GitHub issue here if relevant

#### Before merging this PR
- [x] Fill out the Risks section
- [x] Think about performance and security issues

### Risks
* [RUNTIME] Can this change affect apps rendering for a user? No
* [low] What features does this touch? `installed.js` rendering. Dead code removal.
