### PR TITLE
[DINGO-1836] Expose stripe subscription id

### DIFF
--- a/lib/zendesk_apps_support/installation.rb
+++ b/lib/zendesk_apps_support/installation.rb
@@ -3,7 +3,7 @@
 module ZendeskAppsSupport
   class Installation
     attr_accessor :id, :app_id, :app_name, :requirements, :settings, :enabled, :collapsible, :updated_at, :created_at
-    attr_accessor :plan
+    attr_accessor :plan, :stripe_subscription_id
 
     def initialize(options)
       options.each do |k, v|


### PR DESCRIPTION
🐕

/cc @zendesk/dingo

### Description
Expose stripe subscription id
relate to [PR](https://github.com/zendesk/zendesk_app_market/pull/4981/files#diff-3c4c280a3fd5aba7847463db00c2b01037ed94ca2027a95243f1f7b3daaa8df1R26)

### References
https://zendesk.atlassian.net/browse/DINGO-1836

### Risks
* [low] Adding extra field
