### PR TITLE
Onboards to Ruby Gems Workflow

### DIFF
--- a/.github/workflows/ruby-gem-publication.yml
+++ b/.github/workflows/ruby-gem-publication.yml
@@ -1,0 +1,12 @@
+name: Ruby Gem Publish
+
+on:
+  push:
+    tags: v*
+
+jobs:
+  call-workflow:
+    uses: zendesk/gw/.github/workflows/ruby-gem-publication.yml@main
+    secrets:
+      RUBY_GEMS_API_KEY: ${{ secrets.RUBY_GEMS_API_KEY }}
+      RUBY_GEMS_TOTP_DEVICE: ${{ secrets.RUBY_GEMS_TOTP_DEVICE }}


### PR DESCRIPTION
🐕

/cc @zendesk/dingo

### Description
Ownership for zendesk_apps_support on rubygems.org is being removed ([thread](https://zendesk.slack.com/archives/C2BAXN0JH/p1658113415923469))
We onboard the Ruby Gems Workflow by following [Ruby Gems Workflow Onboarding](https://zendesk.atlassian.net/wiki/spaces/BRE/pages/5443454171/Ruby+Gems+Workflow+Onboarding)

This PR creates `.github/workflows/ruby-gem-publication.yml` according to https://github.com/zendesk/gw/blob/main/ruby-gem-publication/README.md

### References
https://zendesk.slack.com/archives/C2BAXN0JH/p1658113415923469

### Risks
* [low] fail to publish gem
