### PR TITLE
Disable url target v2 target type

### DIFF
--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -174,7 +174,7 @@ module ZendeskAppsSupport
         end
 
         def invalid_target_types(requirements)
-          invalid_target_types = %w[http_target]
+          invalid_target_types = %w[http_target url_target_v2]
 
           requirements['targets']&.map do |_identifier, requirement|
             if invalid_target_types.include?(requirement['type'])

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -197,6 +197,13 @@ describe ZendeskAppsSupport::Validations::Requirements do
             method: 'post',
             target_url: 'http://test.local',
             content_type: 'application/json'
+          },
+          url_target_v2: {
+            type: 'url_target_v2',
+            title: 'URL target v2',
+            method: 'post',
+            target_url: 'http://test.local',
+            content_type: 'application/json'
           }
         }
       }.to_json
@@ -204,6 +211,7 @@ describe ZendeskAppsSupport::Validations::Requirements do
 
     it 'creates an error' do
       expect(errors.first.key).to eq(:invalid_requirements_types)
+      expect(errors.last.key).to eq(:invalid_requirements_types)
     end
   end
 


### PR DESCRIPTION
💐

/cc @zendesk/wattle

### Description
Prevents creating apps with http targets (which are now deprecated). We've already disabled the type `http_target` in https://github.com/zendesk/zendesk_apps_support/pull/325, but `url_target_v2` was missed.

### References
https://zendesk.atlassian.net/browse/APPS-6222

#### Before merging this PR
- [ ] Fill out the Risks section
- [ ] Think about performance and security issues

### Risks
* [RUNTIME] Can this change affect apps rendering for a user? No
* [low] Breaks apps validation
