### PR TITLE
[APPS-6494] Remove deprecated framework versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ PLATFORMS
 
 DEPENDENCIES
   bump (~> 0.5.1)
-  bundler (= 2.2.26)
+  bundler (~> 2.2)
   byebug (~> 9.0.6)
   faker (~> 1.6.6)
   parallel (= 1.12.1)
@@ -100,4 +100,4 @@ DEPENDENCIES
   zendesk_apps_support!
 
 BUNDLED WITH
-   2.2.26
+   2.3.24

--- a/lib/zendesk_apps_support/app_version.rb
+++ b/lib/zendesk_apps_support/app_version.rb
@@ -12,7 +12,7 @@ module ZendeskAppsSupport
   #                  newly created or updates apps MAY target it, but it
   #                  may change without notice
   class AppVersion
-    DEPRECATED = ['0.5', '1.0'].freeze
+    DEPRECATED = [].freeze
     SUNSETTING = nil
     CURRENT    = '2.0'
     FUTURE     = nil
@@ -73,6 +73,4 @@ module ZendeskAppsSupport
       @version == other.to_s
     end
   end
-
-  AppVersion.freeze
 end

--- a/spec/app_version_spec.rb
+++ b/spec/app_version_spec.rb
@@ -31,9 +31,13 @@ describe ZendeskAppsSupport::AppVersion do
   end
 
   describe 'the deprecated version' do
-    let(:sample_version) { ZendeskAppsSupport::AppVersion::DEPRECATED.sample }
+    before do
+      stub_const('ZendeskAppsSupport::AppVersion::DEPRECATED', ['1.0'])
+      stub_const('ZendeskAppsSupport::AppVersion::TO_BE_SERVED', ['1.0'])
+    end
+
     subject do
-      ZendeskAppsSupport::AppVersion.new(sample_version)
+      ZendeskAppsSupport::AppVersion.new('1.0')
     end
 
     it { is_expected.to be_frozen }
@@ -44,17 +48,17 @@ describe ZendeskAppsSupport::AppVersion do
     it { is_expected.not_to be_blank }
     it { is_expected.to be_deprecated }
     it { is_expected.not_to be_obsolete }
-    it { is_expected.to eq(ZendeskAppsSupport::AppVersion.new(sample_version)) }
+    it { is_expected.to eq(ZendeskAppsSupport::AppVersion.new('1.0')) }
     it { is_expected.not_to eq(ZendeskAppsSupport::AppVersion.new('0.2')) }
 
     describe '#to_s' do
       subject { super().to_s }
-      it { is_expected.to eq(sample_version) }
+      it { is_expected.to eq('1.0') }
     end
 
     describe '#to_json' do
       subject { super().to_json }
-      it { is_expected.to eq(sample_version.to_json) }
+      it { is_expected.to eq('"1.0"') }
     end
   end
 

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -393,6 +393,7 @@ describe ZendeskAppsSupport::Package do
       allow(ZendeskAppsSupport::Validations::Marketplace).to receive(:call)
       allow(ZendeskAppsSupport::Validations::Templates).to receive(:call)
       allow(ZendeskAppsSupport::Validations::Stylesheets).to receive(:call)
+      stub_const('ZendeskAppsSupport::AppVersion::TO_BE_SERVED', ['0.5', '2.0'])
       package.validate!(marketplace: false)
     end
 

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -5,13 +5,16 @@ require 'tmpdir'
 
 describe ZendeskAppsSupport::Validations::Manifest do
   def default_required_params(overrides = {})
-    required = ZendeskAppsSupport::Validations::Manifest::REQUIRED_MANIFEST_FIELDS
-    valid_fields = required.values.each_with_object(frameworkVersion: '1.0') do |fields, name|
-      name[fields] = fields
-      name
-    end
-
-    valid_fields.merge(location: 'ticket_sidebar').merge(overrides)
+    {
+      'author' => 'author',
+      'defaultLocale' => 'default ocale',
+      'frameworkVersion' => '2.0',
+      'location' => {
+        'support' => {
+          'ticket_sidebar' => 'url'
+        }
+      }
+    }.merge!(overrides)
   end
 
   def create_package(parameter_hash)

--- a/zendesk_apps_support.gemspec
+++ b/zendesk_apps_support.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'faker', '~> 1.6.6'
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'byebug', '~> 9.0.6'
-  s.add_development_dependency 'bundler', '2.2.26'
+  s.add_development_dependency 'bundler', '~> 2.2'
   s.add_development_dependency 'parallel', '1.12.1'
   s.add_development_dependency 'rake'
 


### PR DESCRIPTION
💐

/cc @zendesk/wattle

### Description
Removes support for deprecated app framework versions.

### References
https://zendesk.atlassian.net/browse/APPS-6494

#### Before merging this PR
- [x] Fill out the Risks section
- [x] Think about performance and security issues

### Risks
* [RUNTIME] Can this change affect apps rendering for a user? No, apps with deprecated versions are not being rendered.
* [low] What features does this touch? App framework version check
