### PR TITLE
Bump version to 4.38.2; GHA chores

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -27,7 +27,9 @@ jobs:
           ${{ runner.os }}-vendor-ruby-${{ matrix.ruby-version }}-
           ${{ runner.os }}-vendor-
     - name: before_script
-      run: bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
+      run: |
+        bundle config set --local path 'vendor/cache'
+        bundle install --jobs=3 --retry=3
     - name: build
       run: |
         bundle exec rake

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -22,7 +22,10 @@ jobs:
       uses: zendesk/cache@v3
       with:
         path: vendor/cache
-        key: ${{ runner.os }}-vendor
+        key: ${{ runner.os }}-vendor-ruby-${{ matrix.ruby-version }}-lock-${{ hashFiles('Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-vendor-ruby-${{ matrix.ruby-version }}-
+          ${{ runner.os }}-vendor-
     - name: before_script
       run: bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
     - name: build

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,13 +13,13 @@ jobs:
       matrix:
         ruby-version: [3.0.4, 2.7.5, 2.6.10]
     steps:
-    - uses: zendesk/checkout@v2
+    - uses: zendesk/checkout@v3
     - uses: zendesk/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
     - name: Vendor Cache
       id: vendor-cache
-      uses: zendesk/cache@v2
+      uses: zendesk/cache@v3
       with:
         path: vendor/cache
         key: ${{ runner.os }}-vendor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_support (4.38.1)
+    zendesk_apps_support (4.38.2)
       erubis
       i18n
       image_size (~> 2.0.2)

--- a/zendesk_apps_support.gemspec
+++ b/zendesk_apps_support.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'zendesk_apps_support'
-  s.version     = '4.38.1'
+  s.version     = '4.38.2'
   s.license     = 'Apache License Version 2.0'
   s.authors     = ['James A. Rosen', 'Likun Liu', 'Sean Caffery', 'Daniel Ribeiro']
   s.email       = ['dev@zendesk.com']


### PR DESCRIPTION
### Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`85f8aa9`](https://github.com/zendesk/zendesk_apps_support/pull/353/commits/85f8aa9bbbb7d0e45177e12ac5e9e348d5f0193c) Bump GitHub Action versions

[1] https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
[2] https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


### [`adc6eac`](https://github.com/zendesk/zendesk_apps_support/pull/353/commits/adc6eace4139dfcd5213e2eb328ed211147c33ee) Improve Actions cache key

This prevents jobs in the matrix from uploading their cache archives
using the same key, while trying to share the archives where possible.


### [`2438e00`](https://github.com/zendesk/zendesk_apps_support/pull/353/commits/2438e006be91e0cd744938a52f806cff6932d573) Fix vendor cache path

Also replaces deprecated flag --path=xxx with bundle config.


### [`89d6d2c`](https://github.com/zendesk/zendesk_apps_support/pull/353/commits/89d6d2ceee0ac67007b7542fce11c8114b755b40) Bump version to 4.38.2



<!-- === GH HISTORY FENCE === -->

### References

https://zendesk.atlassian.net/browse/VEG-1714

#### Before merging this PR
- [x] Fill out the Risks section
- [x] Think about performance and security issues

### Risks
* [RUNTIME] Can this change affect apps rendering for a user?: No
* [Low] What features does this touch?: Manifest validation (last PR #352)
