### PR TITLE
Silent loofah deprecation warning; GHA touch-ups; bump version

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,26 +15,26 @@ jobs:
       matrix:
         ruby-version: [3.0.4, 2.7.5, 2.6.10]
     steps:
-    - uses: zendesk/checkout@v3
-    - uses: zendesk/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-    - name: Vendor Cache
-      id: vendor-cache
-      uses: zendesk/cache@v3
-      with:
-        path: vendor/cache
-        key: ${{ runner.os }}-vendor-ruby-${{ matrix.ruby-version }}-lock-${{ hashFiles('Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-vendor-ruby-${{ matrix.ruby-version }}-
-          ${{ runner.os }}-vendor-
-    - name: before_script
-      run: |
-        bundle config set --local path 'vendor/cache'
-        bundle install --jobs=3 --retry=3
-    - name: build
-      run: |
-        bundle exec rake
-    - name: lint
-      run: |
-        bundle exec rubocop
+      - uses: zendesk/checkout@v3
+      - uses: zendesk/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+      - name: Vendor Cache
+        id: vendor-cache
+        uses: zendesk/cache@v3
+        with:
+          path: vendor/cache
+          key: ${{ runner.os }}-vendor-ruby-${{ matrix.ruby-version }}-lock-${{ hashFiles('Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-vendor-ruby-${{ matrix.ruby-version }}-
+            ${{ runner.os }}-vendor-
+      - name: before_script
+        run: |
+          bundle config set --local path 'vendor/cache'
+          bundle install --jobs=3 --retry=3
+      - name: build
+        run: |
+          bundle exec rake
+      - name: lint
+        run: |
+          bundle exec rubocop

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -2,8 +2,10 @@ name: repo-checks
 
 on:
   pull_request:
+  push:
     branches:
-    - master
+      - master
+      - main
 
 jobs:
   main:

--- a/.github/workflows/ruby-gem-publication.yml
+++ b/.github/workflows/ruby-gem-publication.yml
@@ -2,7 +2,8 @@ name: Ruby Gem Publish
 
 on:
   push:
-    tags: v*
+    tags:
+      - v*
 
 jobs:
   call-workflow:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_support (4.38.2)
+    zendesk_apps_support (4.38.3)
       erubis
       i18n
       image_size (~> 2.0.2)
@@ -100,4 +100,4 @@ DEPENDENCIES
   zendesk_apps_support!
 
 BUNDLED WITH
-   2.3.24
+   2.3.26

--- a/lib/zendesk_apps_support/validations/svg.rb
+++ b/lib/zendesk_apps_support/validations/svg.rb
@@ -8,13 +8,13 @@ module ZendeskAppsSupport
       PLACEHOLDER_SVG_MARKUP = File.read(File.expand_path('../../assets/default_app_logo.svg', __FILE__))
 
       # whitelist elements and attributes used in Zendesk Garden assets
-      Loofah::HTML5::WhiteList::ALLOWED_ELEMENTS_WITH_LIBXML2.add 'symbol'
-      Loofah::HTML5::WhiteList::ACCEPTABLE_CSS_PROPERTIES.add 'position'
+      Loofah::HTML5::SafeList::ALLOWED_ELEMENTS_WITH_LIBXML2.add 'symbol'
+      Loofah::HTML5::SafeList::ACCEPTABLE_CSS_PROPERTIES.add 'position'
 
       # CRUFT: ignore a (very specific) style attribute which Loofah would otherwise scrub.
       # This attribute is deprecated (https://www.w3.org/TR/filter-effects/#AccessBackgroundImage)
       # but is included in many of the test apps used in fixtures for tests in ZAM, ZAT etc.
-      Loofah::HTML5::WhiteList::ACCEPTABLE_CSS_PROPERTIES.add 'enable-background'
+      Loofah::HTML5::SafeList::ACCEPTABLE_CSS_PROPERTIES.add 'enable-background'
 
       @strip_declaration = Loofah::Scrubber.new do |node|
         node.remove if node.name == 'xml' && node.children.empty?

--- a/zendesk_apps_support.gemspec
+++ b/zendesk_apps_support.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'zendesk_apps_support'
-  s.version     = '4.38.2'
+  s.version     = '4.38.3'
   s.license     = 'Apache License Version 2.0'
   s.authors     = ['James A. Rosen', 'Likun Liu', 'Sean Caffery', 'Daniel Ribeiro']
   s.email       = ['dev@zendesk.com']


### PR DESCRIPTION
### Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`c4b7165`](https://github.com/zendesk/zendesk_apps_support/pull/354/commits/c4b71656c3b131e62f81160c1c8bcf5aa8edc38e) Silent loofah deprecation warning

[1] https://github.com/flavorjones/loofah/commit/7cda1210a99721b4fa6fc0f659ac75f00bec6b11


### [`544c515`](https://github.com/zendesk/zendesk_apps_support/pull/354/commits/544c515ff17086c7f16c70d6aa786ce73e2d9eca) Fix CI not running on primary branch



### [`67f05eb`](https://github.com/zendesk/zendesk_apps_support/pull/354/commits/67f05ebafcc6d4b0990ce9eca9cc1983b86deeb7) Format GitHub Action files



### [`1f98f6a`](https://github.com/zendesk/zendesk_apps_support/pull/354/commits/1f98f6a62f6808dde205af311df85ff63a970cdf) Bump version to 4.38.3



<!-- === GH HISTORY FENCE === -->

### References
N/A

#### Before merging this PR
- [x] Fill out the Risks section
- [x] Think about performance and security issues

### Risks
* [RUNTIME] Can this change affect apps rendering for a user? No, it's
    used to validate SVG files.
* [Low] What features does this touch? SVG validation. `SafeList` is an
    alias of the old constant.
