### PR TITLE
Loosen loofah version restriction

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       image_size (~> 2.0.2)
       ipaddress_2 (~> 0.13.0)
       json
-      loofah (>= 2.3.1, < 2.20.0)
+      loofah (>= 2.3.1, <= 2.22.0)
       marcel
       nokogiri
       rb-inotify (= 0.9.10)

--- a/zendesk_apps_support.gemspec
+++ b/zendesk_apps_support.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'json'
   s.add_runtime_dependency 'image_size', '~> 2.0.2'
   s.add_runtime_dependency 'erubis'
-  s.add_runtime_dependency 'loofah', '>= 2.3.1', '< 2.20.0'
+  s.add_runtime_dependency 'loofah', '>= 2.3.1', '<= 2.22.0'
   s.add_runtime_dependency 'nokogiri'
   s.add_runtime_dependency 'rb-inotify', '0.9.10'
   s.add_runtime_dependency 'marcel'


### PR DESCRIPTION
💐

/cc @zendesk/vegemite 

### Description

Makes the loofah dependency requirement looser to unblock the ZBT team. I tested this with ZAT and confirmed unit tests all still pass.

See https://zendesk.slack.com/archives/C1230V1CG/p1704180155370169 for context.

> Hello Team Vegemite :wave: In our framework (ZBT) we are using [zendesk_apps_support](https://github.com/zendesk/zendesk_apps_support), and we are unable to bump rack to address the vulnerability reported by Snyk because of unresolved dependencies. [zendesk_apps_support](https://github.com/zendesk/zendesk_apps_support) requires loofah to be >= 2.3.1', '< 2.20.0, but in ZBT we must bump loofah to 2.22.0 in order to allow us to upgrade rack.
Would you be able to loosen the version restriction so that we can perform the gem upgrade for our framework? Than

### References
Link to a JIRA or GitHub issue here if relevant

#### Before merging this PR
- [ ] Fill out the Risks section
- [ ] Think about performance and security issues

### Risks
* [RUNTIME] Unlikely. Worst case is probably build issues for consumers of this gem.
* [low] Just a dependency version change
