### PR TITLE
[APPS-6946] Add manifest validation to deprecate password type param

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -149,6 +149,8 @@ en:
             oauth_parameter_cannot_be_secure: oauth parameter cannot be set to be
               secure.
             invalid_url: '%{field} must be a valid URL, got "%{value}".'
+            password_parameter_type_deprecated: 'Password parameter type can no longer
+              be used. Use Secure settings instead. Learn more: %{link}.'
         warning:
           app_build:
             deprecated_version: You are targeting a deprecated version of the framework.

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -415,3 +415,7 @@ parts:
       key: "txt.apps.admin.error.app_build.invalid_url"
       title: "App builder job: this value needs to be a valid URL, but something else was passed in. placeholder value is taken from user input. You can translate as: The value %{field} must be a valid URL... to avoid any gender issues."
       value: "%{field} must be a valid URL, got \"%{value}\"."
+  - translation:
+      key: "txt.apps.admin.error.app_build.password_parameter_type_deprecated"
+      title: "App builder job: Password parameter type is deprecated"
+      value: "Password parameter type can no longer be used. Use Secure settings instead. Learn more: %{link}."

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -31,9 +31,9 @@ module ZendeskAppsSupport
       @warnings = []
     end
 
-    def validate(marketplace: true, skip_marketplace_translations: false)
+    def validate(marketplace: true, skip_marketplace_translations: false, apply_password_parameter_check: false)
       errors = []
-      errors << Validations::Manifest.call(self)
+      errors << Validations::Manifest.call(self, apply_password_parameter_check: apply_password_parameter_check)
 
       if has_valid_manifest?(errors)
         errors << Validations::Marketplace.call(self) if marketplace
@@ -61,8 +61,8 @@ module ZendeskAppsSupport
       errors.flatten.compact
     end
 
-    def validate!(marketplace: true, skip_marketplace_translations: false)
-      errors = validate(marketplace: marketplace, skip_marketplace_translations: skip_marketplace_translations)
+    def validate!(marketplace: true, skip_marketplace_translations: false, apply_password_parameter_check: false)
+      errors = validate(marketplace: marketplace, skip_marketplace_translations: skip_marketplace_translations, apply_password_parameter_check: apply_password_parameter_check)
       raise errors.first if errors.any?
       true
     end

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -454,6 +454,18 @@ describe ZendeskAppsSupport::Package do
         expect(ZendeskAppsSupport::Validations::Stylesheets).not_to have_received(:call)
       end
     end
+
+    context 'when apply_password_parameter_check is true' do
+      let(:package) { ZendeskAppsSupport::Package.new('spec/fixtures/iframe_only_app') }
+
+      before do
+        allow(ZendeskAppsSupport::Validations::Manifest).to receive(:call)
+        package.validate!(marketplace: true, apply_password_parameter_check: true)
+      end
+      it 'validate manifest and passes in the apply_password_parameter_check correctly' do
+        expect(ZendeskAppsSupport::Validations::Manifest).to have_received(:call).with(package, {:apply_password_parameter_check => true})
+      end
+    end
   end
 
   describe '#commonjs_modules' do

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -813,4 +813,36 @@ describe ZendeskAppsSupport::Validations::Manifest do
       expect(@package).not_to have_error(/author url must be a valid URL/)
     end
   end
+
+  context 'when the apply_password_parameter_check option is set to false' do
+
+    it 'should be valid with a password param type' do
+      apply_password_parameter_check = false
+      @manifest_hash = {
+        'parameters' => [
+          'name'     => 'a password param',
+          'type'     => 'password',
+        ]}
+        package = create_package(@manifest_hash)
+        errors = ZendeskAppsSupport::Validations::Manifest.call(package, apply_password_parameter_check: apply_password_parameter_check)
+
+      expect(errors.map(&:to_s).join()).not_to include("Password parameter type can no longer be used")
+    end
+  end
+
+  context 'when the apply_password_parameter_check option is set to true' do
+
+    it 'should not be valid with a password param type' do
+      apply_password_parameter_check = true
+      @manifest_hash = {
+        'parameters' => [
+          'name'     => 'a password param',
+          'type'     => 'password',
+        ]}
+        package = create_package(@manifest_hash)
+        errors = ZendeskAppsSupport::Validations::Manifest.call(package, apply_password_parameter_check: apply_password_parameter_check)
+        
+      expect(errors.map(&:to_s).join()).to include("Password parameter type can no longer be used")
+    end
+  end
 end


### PR DESCRIPTION
/cc @zendesk/wattle

Description
Add manifest validation to disallow password type params.
The check is based on enabling _password_parameter_check to ensure this validation works only for new app submission. The value will be passed in from Apps approval and ZAM.

The apply _password_parameter_check value will be passed in from Apps Approval gem [here](https://github.com/zendesk/apps_approval/blob/main/lib/apps_approval/app_validation.rb#L21).

References
https://zendesk.atlassian.net/browse/APPS-6946

Risks
[RUNTIME] No
[low] Only adds an extra validation in manifest that works dependant on skip_password_parameter_check. Manifest validation can fail for apps.