### PR TITLE
Add password parameter deprecation message

### DIFF
--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -355,6 +355,11 @@ parts:
       value: "Make sure to set secure to true when using keys in Settings. Learn more: %{link}"
       screenshot: "https://drive.google.com/open?id=1ss3nNN2RG29R7StjCtiH8qjuwFBlRApJ"
   - translation:
+    key: "txt.apps.admin.error.app_build.translation.password_parameter_deprecated"
+    title: "Validation message to indicate deprecated password parameter is being used. Do not translate 'Password'."
+    value: "Password parameter type is deprecated and will not be accepted in the future. Use Basic Access Authentication instead. Learn more: %{link}."
+    screenshot: "https://drive.google.com/file/d/1S2cecD3h1pIoc5mpG-D966B0gHNlRvhz"
+  - translation:
       key: "txt.apps.admin.error.app_build.translation.default_secure_or_hidden_parameter_in_manifest"
       title: "Validation message to indicate that a hidden or secure manifest parameter has a default value. Do not translate 'secure' and 'hidden'. Secure(true) in manifest refers to https://developer.zendesk.com/apps/docs/developer-guide/using_sdk#using-secure-settings"
       value: "Default values for secure or hidden parameters are not stored securely. Be sure to review them and confirm they do not contain sensitive data"


### PR DESCRIPTION
💐

/cc @zendesk/wattle

### Description
Adds the messaging for the warning that password parameters will be deprecated and should no longer be used.

### References
[Link to a JIRA or GitHub issue here if relevant](https://zendesk.atlassian.net/browse/APPS-7218)

#### Before merging this PR
- [x] Fill out the Risks section
- [x] Think about performance and security issues

### Risks
* [None] String addition for translation
