### PR TITLE
[APPS-7218] Show password parameter warning conditionally

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_support (4.43.0)
+    zendesk_apps_support (4.43.1)
       erubis
       i18n (>= 1.7.1)
       image_size (~> 2.0.2)

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -22,7 +22,7 @@ module ZendeskAppsSupport
             return [ValidationError.new(:missing_manifest)]
           end
 
-          package.warnings << password_parameter_warning unless error_on_password_parameter
+          package.warnings << password_parameter_warning if !error_on_password_parameter && password_param_present?(package.manifest)
 
           collate_manifest_errors(package, error_on_password_parameter)
         rescue JSON::ParserError => e
@@ -32,6 +32,10 @@ module ZendeskAppsSupport
         end
 
         private
+
+        def password_param_present?(manifest)
+          manifest.parameters.any? { |p| p.type == 'password' }
+        end
 
         def collate_manifest_errors(package, error_on_password_parameter)
           manifest = package.manifest
@@ -214,7 +218,7 @@ module ZendeskAppsSupport
 
         def deprecate_password_parameter_type(manifest)
           secure_settings_link = 'https://developer.zendesk.com/documentation/apps/app-developer-guide/making-api-requests-from-a-zendesk-app/#using-secure-settings'
-          if manifest.parameters.any? { |p| p.type == 'password' }
+          if password_param_present?(manifest)
             ValidationError.new(:password_parameter_type_deprecated, link: secure_settings_link)
           end
         end

--- a/lib/zendesk_apps_support/version.rb
+++ b/lib/zendesk_apps_support/version.rb
@@ -1,3 +1,3 @@
 module ZendeskAppsSupport
-  VERSION = "4.43.0"
+  VERSION = "4.43.1"
 end

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -814,37 +814,54 @@ describe ZendeskAppsSupport::Validations::Manifest do
     end
   end
 
-  context 'when the error_on_password_parameter option is set to false' do
+  context 'password parameter validations' do
+    password_parameter_error_message = 'Password parameter type can no longer be used'
+    password_parameter_warning_message = 'Password parameter type is deprecated and will not be accepted in the future'
 
-    it 'should be valid but add a warning about the password param type' do
-      error_on_password_parameter = false
-      @manifest_hash = {
-        'parameters' => [
-          'name'     => 'a password param',
-          'type'     => 'password',
-        ]}
-        package = create_package(@manifest_hash)
-        errors = ZendeskAppsSupport::Validations::Manifest.call(package, error_on_password_parameter: error_on_password_parameter)
+    context 'when the error_on_password_parameter option is set to false' do
+      describe 'when the password parameter type is present' do
+        it 'should be valid but add a warning about the password param type' do
+          error_on_password_parameter = false
+          @manifest_hash = {
+            'parameters' => [
+              'name'     => 'a password param',
+              'type'     => 'password',
+            ]}
+            package = create_package(@manifest_hash)
+            errors = ZendeskAppsSupport::Validations::Manifest.call(package, error_on_password_parameter: error_on_password_parameter)
 
-      expect(errors.map(&:to_s).join()).not_to include("Password parameter type can no longer be used")
-      expect(package.warnings.join()).to include("Password parameter type is deprecated and will not be accepted in the future")
+          expect(errors.map(&:to_s).join()).not_to include(password_parameter_error_message)
+          expect(package.warnings.join()).to include(password_parameter_warning_message)
+        end
+      end
+
+      describe 'when the password parameter type is not present' do
+        it 'should be valid and add no warnings about a password parameter' do
+          error_on_password_parameter = false
+          @manifest_hash = {}
+            package = create_package(@manifest_hash)
+            errors = ZendeskAppsSupport::Validations::Manifest.call(package, error_on_password_parameter: error_on_password_parameter)
+
+          expect(errors.map(&:to_s).join()).not_to include(password_parameter_error_message)
+          expect(package.warnings.join()).not_to include(password_parameter_warning_message)
+        end
+      end
     end
-  end
 
-  context 'when the error_on_password_parameter option is set to true' do
+    context 'when the error_on_password_parameter option is set to true' do
+      it 'should not be valid with a password param type and add no warnings' do
+        error_on_password_parameter = true
+        @manifest_hash = {
+          'parameters' => [
+            'name'     => 'a password param',
+            'type'     => 'password',
+          ]}
+          package = create_package(@manifest_hash)
+          errors = ZendeskAppsSupport::Validations::Manifest.call(package, error_on_password_parameter: error_on_password_parameter)
 
-    it 'should not be valid with a password param type and add no warnings' do
-      error_on_password_parameter = true
-      @manifest_hash = {
-        'parameters' => [
-          'name'     => 'a password param',
-          'type'     => 'password',
-        ]}
-        package = create_package(@manifest_hash)
-        errors = ZendeskAppsSupport::Validations::Manifest.call(package, error_on_password_parameter: error_on_password_parameter)
-
-      expect(errors.map(&:to_s).join()).to include("Password parameter type can no longer be used")
-      expect(package.warnings.join()).not_to include("Password parameter type is deprecated and will not be accepted in the future")
+        expect(errors.map(&:to_s).join()).to include(password_parameter_error_message)
+        expect(package.warnings.join()).not_to include(password_parameter_warning_message)
+      end
     end
   end
 end


### PR DESCRIPTION
💐

/cc @zendesk/wattle

### Description
The warning regarding password parameter deprecation was mistakenly being added on every single validation.
This change updates the logic to only show the warning if a parameter of type 'password' is present in the manifest.

### References
[APPS-7218](https://zendesk.atlassian.net/browse/APPS-7218)

#### Before merging this PR
- [x] Fill out the Risks section
- [x] Think about performance and security issues

### Risks
* [low] Password parameter warning is not added appropriately.
* [low] Issues with validation flow.