### PR TITLE
[CRYSTAL-484]Enforce referential integrity validation for CustomObjectsV2

### DIFF
--- a/lib/zendesk_apps_support/validations/custom_objects_v2/constants.rb
+++ b/lib/zendesk_apps_support/validations/custom_objects_v2/constants.rb
@@ -47,6 +47,11 @@ module ZendeskAppsSupport
         UNDEFINED_VALUE = '(undefined)'
         CONDITION_KEYS = [ALL, ANY].freeze
         MAX_PAYLOAD_SIZE_BYTES = 1_048_576 # 1 MB in bytes
+
+        REFERENCE_VALIDATION_CONFIG = {
+          SCHEMA_KEYS[:object_fields] => { identifier: KEY, error: :invalid_cov2_object_reference_in_fields },
+          SCHEMA_KEYS[:object_triggers] => { identifier: TITLE, error: :invalid_cov2_object_reference_in_triggers }
+        }.freeze
       end
     end
   end

--- a/lib/zendesk_apps_support/validations/custom_objects_v2/schema_validator.rb
+++ b/lib/zendesk_apps_support/validations/custom_objects_v2/schema_validator.rb
@@ -103,10 +103,6 @@ module ZendeskAppsSupport
             [ValidationError.new(:empty_cov2_trigger_actions, **error_data)]
           end
 
-          def safe_value(value)
-            value || UNDEFINED_VALUE
-          end
-
           def valid_conditions_structure?(conditions)
             return false unless conditions.is_a?(Hash) && conditions.any?
             return false if (conditions.keys - CONDITION_KEYS).any?

--- a/lib/zendesk_apps_support/validations/custom_objects_v2/validation_helpers.rb
+++ b/lib/zendesk_apps_support/validations/custom_objects_v2/validation_helpers.rb
@@ -4,6 +4,8 @@ module ZendeskAppsSupport
   module Validations
     module CustomObjectsV2
       module ValidationHelpers
+        include Constants
+
         private
 
         def extract_hash_entries(collection)
@@ -16,6 +18,10 @@ module ZendeskAppsSupport
           return 0 unless conditions.is_a?(Hash)
 
           Constants::CONDITION_KEYS.sum { |key| conditions[key]&.size || 0 }
+        end
+
+        def safe_value(value)
+          value || UNDEFINED_VALUE
         end
       end
     end

--- a/spec/validations/custom_objects_v2/custom_objects_v2_spec.rb
+++ b/spec/validations/custom_objects_v2/custom_objects_v2_spec.rb
@@ -77,6 +77,35 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2 do
           'object_triggers' => []
         },
         description: 'payload exceeds size limit'
+      },
+      {
+        error: :invalid_cov2_object_reference_in_triggers,
+        requirements: {
+          'objects' => [
+            { 'key' => 'object_1', 'title' => 'Object 1', 'title_pluralized' => 'Objects 1',
+              'include_in_list_view' => true }
+          ],
+          'object_fields' => [],
+          'object_triggers' => [
+            { 'title' => 'Trigger 1', 'object_key' => 'invalid_object', 
+              'conditions' => { 'all' => [{ 'field' => 'status', 'operator' => 'is', 'value' => 'open' }] },
+              'actions' => [{ 'field' => 'status', 'value' => 'closed' }] }
+          ]
+        },
+        description: 'object_trigger references non-existent object'
+      },
+      {
+        error: :invalid_cov2_object_reference_in_fields,
+        requirements: {
+          'objects' => [
+            { 'key' => 'object_1', 'title' => 'Object 1', 'title_pluralized' => 'Objects 1',
+              'include_in_list_view' => true }
+          ],
+          'object_fields' => [
+            { 'object_key' => 'invalid_object', 'key' => 'field_1', 'type' => 'text', 'title' => 'Field 1' }
+          ]
+        },
+        description: 'object_field references non-existent object'
       }
     ].each do |test_case|
       context "when #{test_case[:description]}" do

--- a/spec/validations/custom_objects_v2/validation_helpers_spec.rb
+++ b/spec/validations/custom_objects_v2/validation_helpers_spec.rb
@@ -8,7 +8,7 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2::ValidationHelpers do
       class << self
         include ZendeskAppsSupport::Validations::CustomObjectsV2::ValidationHelpers
 
-        public :extract_hash_entries, :count_conditions
+        public :extract_hash_entries, :count_conditions, :safe_value
       end
     end
   end
@@ -65,6 +65,27 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2::ValidationHelpers do
       context "when #{test_case[:description]}" do
         it 'returns expected result' do
           expect(test_class.count_conditions(test_case[:input])).to eq(test_case[:expected])
+        end
+      end
+    end
+  end
+
+  describe '.safe_value' do
+    [
+      {
+        input: nil,
+        expected: '(undefined)',
+        description: 'value is nil'
+      },
+      {
+        input: 'valid_key',
+        expected: 'valid_key',
+        description: 'value is not nil'
+      }
+    ].each do |test_case|
+      context "when #{test_case[:description]}" do
+        it 'returns expected result' do
+          expect(test_class.safe_value(test_case[:input])).to eq(test_case[:expected])
         end
       end
     end


### PR DESCRIPTION
💐

/cc @zendesk/wattle

### Description

Added referential integrity validation - prevents object_fields and object_triggers from referencing non-existent objects

### References
[JIRA](https://zendesk.atlassian.net/browse/CRYSTAL-484)
[Reference PR for Cov2 validations](https://github.com/zendesk/zendesk_apps_support/pull/383)

#### Before merging this PR
- [ ] Fill out the Risks section
- [ ] Think about performance and security issues

### Risks
* [RUNTIME] Can this change affect apps rendering for a user?
* [HIGH | medium | low] What features does this touch?
medium: Right now, it does not touch any existing feature. We are introducing a new `resource_type` which is not yet used in ZAM or any of the existing apps.
