### PR TITLE
[CRYSTAL-498]Add unique key in trigger schema

### DIFF
--- a/lib/zendesk_apps_support/app_requirement.rb
+++ b/lib/zendesk_apps_support/app_requirement.rb
@@ -7,6 +7,9 @@ module ZendeskAppsSupport
     CUSTOM_OBJECTS_TYPE_KEY = 'custom_object_types'
     CUSTOM_OBJECTS_RELATIONSHIP_TYPE_KEY = 'custom_object_relationship_types'
     CUSTOM_OBJECTS_V2_KEY = 'custom_objects_v2'
+    CUSTOM_OBJECTS_V2_OBJECTS_KEY = 'objects'
+    CUSTOM_OBJECTS_V2_OBJECT_FIELDS_KEY = 'object_fields'
+    CUSTOM_OBJECT_V2_OBJECT_TRIGGERS_KEY = 'object_triggers'
     TYPES = %w[automations channel_integrations custom_objects macros targets views ticket_fields
                triggers user_fields organization_fields webhooks custom_objects_v2].freeze
   end

--- a/lib/zendesk_apps_support/validations/custom_objects_v2/schema_validator.rb
+++ b/lib/zendesk_apps_support/validations/custom_objects_v2/schema_validator.rb
@@ -60,7 +60,7 @@ module ZendeskAppsSupport
           end
 
           def validate_trigger_schema(trigger)
-            required_keys = %w[object_key title actions conditions]
+            required_keys = %w[key object_key title actions conditions]
             missing_keys = required_keys - trigger.keys
             trigger_title = safe_value(trigger[TITLE])
             object_key = safe_value(trigger[OBJECT_KEY])

--- a/spec/validations/custom_objects_v2/custom_objects_v2_spec.rb
+++ b/spec/validations/custom_objects_v2/custom_objects_v2_spec.rb
@@ -35,8 +35,8 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2 do
           'objects' => {},
           'object_fields' => [{ 'key' => 'field_1', 'type' => 'text', 'title' => 'Field 1',
                                 'object_key' => 'object_1' }],
-          'object_triggers' => [{ 'title' => 'Trigger 1', 'object_key' => 'object_1', 'conditions' => { 'all' => [] },
-                                  'actions' => [] }]
+          'object_triggers' => [{ 'key' => 'trigger_1', 'title' => 'Trigger 1', 'object_key' => 'object_1',
+                                  'conditions' => { 'all' => [] }, 'actions' => [] }]
         },
         description: 'objects is not an array'
       },
@@ -46,8 +46,8 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2 do
           'objects' => [{ 'key' => 'object_1', 'title' => 'Object 1', 'title_pluralized' => 'Objects 1',
                           'include_in_list_view' => true }],
           'object_fields' => {},
-          'object_triggers' => [{ 'title' => 'Trigger 1', 'object_key' => 'object_1', 'conditions' => { 'all' => [] },
-                                  'actions' => [] }]
+          'object_triggers' => [{ 'key' => 'trigger_1', 'title' => 'Trigger 1', 'object_key' => 'object_1',
+                                  'conditions' => { 'all' => [] }, 'actions' => [] }]
         },
         description: 'object_fields is not an array'
       },
@@ -87,7 +87,7 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2 do
           ],
           'object_fields' => [],
           'object_triggers' => [
-            { 'title' => 'Trigger 1', 'object_key' => 'invalid_object', 
+            { 'key' => 'trigger_1', 'title' => 'Trigger 1', 'object_key' => 'invalid_object',
               'conditions' => { 'all' => [{ 'field' => 'status', 'operator' => 'is', 'value' => 'open' }] },
               'actions' => [{ 'field' => 'status', 'value' => 'closed' }] }
           ]
@@ -137,6 +137,7 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2 do
           ],
           'object_triggers' => [
             {
+              'key' => 'trigger_1',
               'title' => 'Priority Trigger',
               'object_key' => 'ticket_object',
               'conditions' => { 'all' => [{ 'field' => 'priority', 'operator' => 'is', 'value' => 'high' }] },

--- a/spec/validations/custom_objects_v2/limits_validator_spec.rb
+++ b/spec/validations/custom_objects_v2/limits_validator_spec.rb
@@ -72,7 +72,8 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2::LimitsValidator do
           'objects' => [{ 'key' => 'object_1', 'title' => 'Object 1' }],
           'object_fields' => [],
           'object_triggers' => Array.new(21) do |i|
-            { 'title' => "Trigger #{i}", 'object_key' => 'object_1', 'conditions' => { 'all' => [] }, 'actions' => [] }
+            { 'key' => "trigger_#{i}", 'title' => "Trigger #{i}", 'object_key' => 'object_1',
+              'conditions' => { 'all' => [] }, 'actions' => [] }
           end
         },
         description: 'there are more than 20 triggers per object'
@@ -83,6 +84,7 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2::LimitsValidator do
           'objects' => [{ 'key' => 'object_1', 'title' => 'Object 1' }],
           'object_fields' => [],
           'object_triggers' => [{
+            'key' => 'trigger_1',
             'title' => 'Trigger 1',
             'object_key' => 'object_1',
             'conditions' => {
@@ -99,6 +101,7 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2::LimitsValidator do
           'objects' => [{ 'key' => 'object_1', 'title' => 'Object 1' }],
           'object_fields' => [],
           'object_triggers' => [{
+            'key' => 'trigger_1',
             'title' => 'Trigger 1',
             'object_key' => 'object_1',
             'conditions' => { 'all' => [] },
@@ -138,6 +141,7 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2::LimitsValidator do
           ],
           'object_triggers' => [
             {
+              'key' => 'order_processing_trigger',
               'title' => 'Order Processing Trigger',
               'object_key' => 'order_object',
               'conditions' => {
@@ -170,6 +174,7 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2::LimitsValidator do
           ],
           'object_triggers' => [
             {
+              'key' => 'assignment_trigger',
               'title' => 'Ticket Assignment Trigger',
               'object_key' => 'ticket_object',
               'conditions' => { 'all' => [{ 'field' => 'priority', 'operator' => 'is', 'value' => 'high' }] },

--- a/spec/validations/custom_objects_v2/schema_validator_spec.rb
+++ b/spec/validations/custom_objects_v2/schema_validator_spec.rb
@@ -41,6 +41,7 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2::SchemaValidator do
                           'include_in_list_view' => true }],
           'object_fields' => [],
           'object_triggers' => [{
+            'key' => 'trigger_1',
             'object_key' => 'object_1',
             'title' => 'Trigger 1',
             'actions' => [{ 'field' => 'status', 'value' => 'resolved' }],
@@ -56,6 +57,7 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2::SchemaValidator do
                           'include_in_list_view' => true }],
           'object_fields' => [],
           'object_triggers' => [{
+            'key' => 'trigger_1',
             'object_key' => 'object_1',
             'title' => 'Trigger 1',
             'actions' => [{ 'field' => 'status', 'value' => 'resolved' }],
@@ -71,6 +73,7 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2::SchemaValidator do
                           'include_in_list_view' => true }],
           'object_fields' => [],
           'object_triggers' => [{
+            'key' => 'trigger_1',
             'object_key' => 'object_1',
             'title' => 'Trigger 1',
             'actions' => 'not_an_array',
@@ -86,6 +89,7 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2::SchemaValidator do
                           'include_in_list_view' => true }],
           'object_fields' => [],
           'object_triggers' => [{
+            'key' => 'trigger_1',
             'object_key' => 'object_1',
             'title' => 'Trigger 1',
             'actions' => [],
@@ -124,6 +128,7 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2::SchemaValidator do
           ],
           'object_triggers' => [
             {
+              'key' => 'trigger_1',
               'object_key' => 'ticket_object',
               'title' => 'Priority Trigger',
               'actions' => [{ 'field' => 'status', 'value' => 'resolved' }],
@@ -153,6 +158,7 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2::SchemaValidator do
           ],
           'object_triggers' => [
             {
+              'key' => 'trigger_1',
               'object_key' => 'user_object',
               'title' => 'Department Trigger',
               'actions' => [{ 'field' => 'assignee', 'value' => 'manager' }],
@@ -182,6 +188,7 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2::SchemaValidator do
           ],
           'object_triggers' => [
             {
+              'key' => 'trigger_1',
               'object_key' => 'task_object',
               'title' => 'Mixed Trigger',
               'actions' => [{ 'field' => 'priority', 'value' => 'urgent' }],


### PR DESCRIPTION
💐

/cc @zendesk/wattle

### Description
The PR includes changes related to addition of unique `key` in triggers schema. It also includes addition of new constants.

New schema would look like this:

```
  {
  "custom_objects_v2": {
    "objects": [{......}],
    "object_fields": [{.....}],
    "object_triggers": [
      {
        "key": "welcome_trigger"
        "title": "Welcome Trigger",
        "object_key": "apartment",
        "conditions": {
          "all": [],
          "any": [
            {"field": "priority", "operator": "is", "value": "urgent"},
            {"field": "type", "operator": "is", "value": "incident"}
          ]
        },
        "actions": [
          {"field": "assignee_id", "value": "123456789"}
        ]
      }
    ]
  }
}
```

### References
[Link to a JIRA or GitHub issue here if relevant](https://zendesk.atlassian.net/browse/CRYSTAL-498)

#### Before merging this PR
- [ ] Fill out the Risks section
- [ ] Think about performance and security issues

### Risks
* [RUNTIME] Can this change affect apps rendering for a user?
* [HIGH | medium | low] What features does this touch?
Low: Adding just constants and and new schema key
