### PR TITLE
[CRYSTAL-514] Add a flag for the gating validation of cov2 requirements

### DIFF
--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -31,7 +31,8 @@ module ZendeskAppsSupport
       @warnings = []
     end
 
-    def validate(marketplace: true, skip_marketplace_translations: false, error_on_password_parameter: false)
+    def validate(marketplace: true, skip_marketplace_translations: false, error_on_password_parameter: false,
+                 validate_custom_objects_v2: false)
       errors = []
       errors << Validations::Manifest.call(self, error_on_password_parameter: error_on_password_parameter)
 
@@ -39,7 +40,7 @@ module ZendeskAppsSupport
         errors << Validations::Marketplace.call(self) if marketplace
         errors << Validations::Source.call(self)
         errors << Validations::Translations.call(self, skip_marketplace_translations: skip_marketplace_translations)
-        errors << Validations::Requirements.call(self)
+        errors << Validations::Requirements.call(self, validate_custom_objects_v2:)
 
         # only adds warnings
         Validations::SecureSettings.call(self)
@@ -61,9 +62,14 @@ module ZendeskAppsSupport
       errors.flatten.compact
     end
 
-    def validate!(marketplace: true, skip_marketplace_translations: false, error_on_password_parameter: false)
-      errors = validate(marketplace: marketplace, skip_marketplace_translations: skip_marketplace_translations, error_on_password_parameter: error_on_password_parameter)
+    def validate!(marketplace: true, skip_marketplace_translations: false, error_on_password_parameter: false,
+                  validate_custom_objects_v2: false)
+      errors = validate(marketplace: marketplace,
+                        skip_marketplace_translations: skip_marketplace_translations,
+                        error_on_password_parameter: error_on_password_parameter,
+                        validate_custom_objects_v2:)
       raise errors.first if errors.any?
+
       true
     end
 

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -7,7 +7,7 @@ module ZendeskAppsSupport
       MAX_CUSTOM_OBJECTS_REQUIREMENTS = 50
 
       class << self
-        def call(package)
+        def call(package, validate_custom_objects_v2: false)
           if package.manifest.requirements_only? && !package.has_requirements?
             return [ValidationError.new(:missing_requirements)]
           elsif !supports_requirements(package) && package.has_requirements?
@@ -31,7 +31,7 @@ module ZendeskAppsSupport
             errors << invalid_custom_objects(requirements)
             errors << invalid_webhooks(requirements)
             errors << invalid_target_types(requirements)
-            errors << validate_custom_objects_v2_requirements(requirements)
+            errors << validate_custom_objects_v2_requirements(requirements, validate_custom_objects_v2:)
             errors << missing_required_fields(requirements)
             errors.flatten!
             errors.compact!
@@ -80,8 +80,8 @@ module ZendeskAppsSupport
           end
         end
 
-        def validate_custom_objects_v2_requirements(requirements)
-          return unless requirements.key?(AppRequirement::CUSTOM_OBJECTS_V2_KEY)
+        def validate_custom_objects_v2_requirements(requirements, validate_custom_objects_v2: false)
+          return unless validate_custom_objects_v2 && requirements.key?(AppRequirement::CUSTOM_OBJECTS_V2_KEY)
 
           cov2_requirements = requirements[AppRequirement::CUSTOM_OBJECTS_V2_KEY]
           CustomObjectsV2.call(cov2_requirements)

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -466,6 +466,19 @@ describe ZendeskAppsSupport::Package do
         expect(ZendeskAppsSupport::Validations::Manifest).to have_received(:call).with(package, {:error_on_password_parameter => true})
       end
     end
+
+    context 'when validate_custom_objects_v2 is true' do
+      let(:package) { ZendeskAppsSupport::Package.new('spec/fixtures/iframe_only_app') }
+
+      before do
+        allow(ZendeskAppsSupport::Validations::Requirements).to receive(:call)
+        package.validate!(marketplace: true, validate_custom_objects_v2: true)
+      end
+      it 'validates requirements and passes in the validate_custom_objects_v2 correctly' do
+        expect(ZendeskAppsSupport::Validations::Requirements).to have_received(:call)
+          .with(package, { validate_custom_objects_v2: true })
+      end
+    end
   end
 
   describe '#commonjs_modules' do


### PR DESCRIPTION

💐

/cc @zendesk/wattle

### Description

The PR includes changes related to addition of flag to prevent validation of cov2 requirements when feature flag is disabled in ZAM.
- Extend Package#validate/validate! with custom_objects_v2_requirements parameter
- Update Requirements.call to conditionally validate COV2 based on opts flag
- Add thorough test coverage for both enabled/disabled validation scenarios


### References
[Link to a JIRA or GitHub issue here if relevant](https://zendesk.atlassian.net/browse/CRYSTAL-514)

#### Before merging this PR
- [ ] Fill out the Risks section
- [ ] Think about performance and security issues

### Risks
* [RUNTIME] Can this change affect apps rendering for a user?
Yes, it is called during app zip validation
* [HIGH | medium | low] What features does this touch?
Low: This change is called during zip validation 
