### PR TITLE
[CRYSTAL-950] Update COV2 limits & bump new version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_support (4.47.0)
+    zendesk_apps_support (4.48.0)
       erubis
       i18n (>= 1.7.1)
       image_size (~> 2.0.2)

--- a/lib/zendesk_apps_support/validations/custom_objects_v2/constants.rb
+++ b/lib/zendesk_apps_support/validations/custom_objects_v2/constants.rb
@@ -5,8 +5,8 @@ module ZendeskAppsSupport
     module CustomObjectsV2
       module Constants
         MAX_OBJECTS = 50
-        MAX_FIELDS_PER_OBJECT = 10
-        MAX_TRIGGERS_PER_OBJECT = 20
+        MAX_FIELDS_PER_OBJECT = 20
+        MAX_TRIGGERS_PER_OBJECT = 10
         MAX_CONDITIONS_PER_TRIGGER = 50
         MAX_ACTIONS_PER_TRIGGER = 25
         MAX_CONDITIONS_IN_RELATIONSHIP_FILTER_PER_OBJECT = 20

--- a/lib/zendesk_apps_support/version.rb
+++ b/lib/zendesk_apps_support/version.rb
@@ -1,3 +1,3 @@
 module ZendeskAppsSupport
-  VERSION = '4.47.0'
+  VERSION = '4.48.0'
 end

--- a/spec/validations/custom_objects_v2/limits_validator_spec.rb
+++ b/spec/validations/custom_objects_v2/limits_validator_spec.rb
@@ -18,7 +18,7 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2::LimitsValidator do
         error: :excessive_custom_objects_v2_fields,
         requirements: {
           'objects' => [{ 'key' => 'object_1', 'title' => 'Object 1' }],
-          'object_fields' => Array.new(11) do |i|
+          'object_fields' => Array.new(21) do |i|
             { 'key' => "field_#{i}", 'type' => 'text', 'object_key' => 'object_1' }
           end,
           'object_triggers' => []
@@ -71,7 +71,7 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2::LimitsValidator do
         requirements: {
           'objects' => [{ 'key' => 'object_1', 'title' => 'Object 1' }],
           'object_fields' => [],
-          'object_triggers' => Array.new(21) do |i|
+          'object_triggers' => Array.new(11) do |i|
             { 'key' => "trigger_#{i}", 'title' => "Trigger #{i}", 'object_key' => 'object_1',
               'conditions' => { 'all' => [] }, 'actions' => [] }
           end
@@ -145,7 +145,9 @@ describe ZendeskAppsSupport::Validations::CustomObjectsV2::LimitsValidator do
               'title' => 'Order Processing Trigger',
               'object_key' => 'order_object',
               'conditions' => {
-                'all' => Array.new(50) { |i| { 'field' => "condition_field_#{i}", 'operator' => 'is', 'value' => "value_#{i}" } }
+                'all' => Array.new(50) do |i|
+                  { 'field' => "condition_field_#{i}", 'operator' => 'is', 'value' => "value_#{i}" }
+                end
               },
               'actions' => Array.new(25) { |i| { 'field' => "action_field_#{i}", 'value' => "action_value_#{i}" } }
             }


### PR DESCRIPTION
💐

/cc @zendesk/wattle

### Description

- Increase `MAX_FIELDS_PER_OBJECT` from 10 to 20
- Decrease `MAX_TRIGGERS_PER_OBJECT` from 20 to 10
- Bump version to 4.48.0
- Update specs to reflect new limits

### References
JIRA: https://zendesk.atlassian.net/browse/CRYSTAL-950
#### Before merging this PR
- [x] Fill out the Risks section
- [x] Think about performance and security issues

### Risks
* [low]  Validation-only changes in ZAS & bump changes
