### PR TITLE
[CRYSTAL-923] Remove conditional cov2 requirements validation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_support (4.48.0)
+    zendesk_apps_support (4.49.0)
       erubis
       i18n (>= 1.7.1)
       image_size (~> 2.0.2)

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -35,7 +35,6 @@ module ZendeskAppsSupport
       marketplace = options.fetch(:marketplace, true)
       skip_marketplace_translations = options.fetch(:skip_marketplace_translations, false)
       error_on_password_parameter = options.fetch(:error_on_password_parameter, false)
-      validate_custom_objects_v2 = options.fetch(:validate_custom_objects_v2, false)
 
       errors = []
       errors << Validations::Manifest.call(self, error_on_password_parameter: error_on_password_parameter)
@@ -44,7 +43,7 @@ module ZendeskAppsSupport
         errors << Validations::Marketplace.call(self) if marketplace
         errors << Validations::Source.call(self)
         errors << Validations::Translations.call(self, skip_marketplace_translations: skip_marketplace_translations)
-        errors << Validations::Requirements.call(self, validate_custom_objects_v2:)
+        errors << Validations::Requirements.call(self)
 
         # only adds warnings
         Validations::SecureSettings.call(self)

--- a/lib/zendesk_apps_support/validations/requirements.rb
+++ b/lib/zendesk_apps_support/validations/requirements.rb
@@ -7,7 +7,7 @@ module ZendeskAppsSupport
       MAX_CUSTOM_OBJECTS_REQUIREMENTS = 50
 
       class << self
-        def call(package, validate_custom_objects_v2: false)
+        def call(package)
           if package.manifest.requirements_only? && !package.has_requirements?
             return [ValidationError.new(:missing_requirements)]
           elsif !supports_requirements(package) && package.has_requirements?
@@ -31,7 +31,7 @@ module ZendeskAppsSupport
             errors << invalid_custom_objects(requirements)
             errors << invalid_webhooks(requirements)
             errors << invalid_target_types(requirements)
-            errors << validate_custom_objects_v2_requirements(requirements, validate_custom_objects_v2:)
+            errors << validate_custom_objects_v2_requirements(requirements)
             errors << missing_required_fields(requirements)
             errors.flatten!
             errors.compact!
@@ -80,8 +80,8 @@ module ZendeskAppsSupport
           end
         end
 
-        def validate_custom_objects_v2_requirements(requirements, validate_custom_objects_v2: false)
-          return unless validate_custom_objects_v2 && requirements.key?(AppRequirement::CUSTOM_OBJECTS_V2_KEY)
+        def validate_custom_objects_v2_requirements(requirements)
+          return unless requirements.key?(AppRequirement::CUSTOM_OBJECTS_V2_KEY)
 
           cov2_requirements = requirements[AppRequirement::CUSTOM_OBJECTS_V2_KEY]
           CustomObjectsV2.call(cov2_requirements)

--- a/lib/zendesk_apps_support/version.rb
+++ b/lib/zendesk_apps_support/version.rb
@@ -1,3 +1,3 @@
 module ZendeskAppsSupport
-  VERSION = '4.48.0'
+  VERSION = '4.49.0'
 end

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -455,19 +455,6 @@ describe ZendeskAppsSupport::Package do
       end
     end
 
-    context 'when validate_custom_objects_v2 is true' do
-      let(:package) { ZendeskAppsSupport::Package.new('spec/fixtures/iframe_only_app') }
-
-      before do
-        allow(ZendeskAppsSupport::Validations::Requirements).to receive(:call)
-        package.validate!(marketplace: true, validate_custom_objects_v2: true)
-      end
-      it 'validates requirements and passes in the validate_custom_objects_v2 correctly' do
-        expect(ZendeskAppsSupport::Validations::Requirements).to have_received(:call)
-          .with(package, { validate_custom_objects_v2: true })
-      end
-    end
-
     context 'when handling validation options' do
       let(:package) { ZendeskAppsSupport::Package.new('spec/fixtures/iframe_only_app') }
 
@@ -494,10 +481,7 @@ describe ZendeskAppsSupport::Package do
           package,
           { skip_marketplace_translations: false }
         )
-        expect(ZendeskAppsSupport::Validations::Requirements).to have_received(:call).with(
-          package,
-          { validate_custom_objects_v2: false }
-        )
+        expect(ZendeskAppsSupport::Validations::Requirements).to have_received(:call).with(package)
       end
 
       it 'ignores unknown options without raising error' do

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -390,66 +390,30 @@ describe ZendeskAppsSupport::Validations::Requirements do
       )
     end
 
-    context 'when validate_custom_objects_v2 is false (default)' do
-      context 'with no custom_objects_v2 requirements' do
-        let(:requirements_string) { non_cov2_requirements }
+    context 'with no custom_objects_v2 requirements' do
+      let(:requirements_string) { non_cov2_requirements }
 
-        it 'calls validate_custom_objects_v2_requirements but returns early due to flag' do
-          expect(ZendeskAppsSupport::Validations::Requirements)
-            .to receive(:validate_custom_objects_v2_requirements).and_call_original
-          expect(ZendeskAppsSupport::Validations::CustomObjectsV2).not_to receive(:call)
-          expect(errors).to be_empty
-        end
-      end
-
-      context 'with excessive custom_objects_v2 requirements' do
-        let(:requirements_string) { excessive_objects_requirements }
-
-        it 'calls validate_custom_objects_v2_requirements but returns early due to flag' do
-          expect(ZendeskAppsSupport::Validations::Requirements)
-            .to receive(:validate_custom_objects_v2_requirements).and_call_original
-          expect(ZendeskAppsSupport::Validations::CustomObjectsV2).not_to receive(:call)
-          expect(errors).to be_empty
-        end
+      it 'does not invoke CustomObjectsV2 validator' do
+        expect(ZendeskAppsSupport::Validations::CustomObjectsV2).not_to receive(:call)
+        expect(errors).to be_empty
       end
     end
 
-    context 'when validate_custom_objects_v2 is true' do
-      let(:errors) do
-        ZendeskAppsSupport::Validations::Requirements.call(package, validate_custom_objects_v2: true)
+    context 'with excessive custom_objects_v2 requirements' do
+      let(:requirements_string) { excessive_objects_requirements }
+
+      it 'validates max custom object limits' do
+        expect(errors.first.key).to eq(:excessive_custom_objects_v2_requirements)
+        expect(errors.first.data).to eq(max: 50, count: 51)
       end
+    end
 
-      context 'with no custom_objects_v2 requirements' do
-        let(:requirements_string) { non_cov2_requirements }
+    context 'with valid custom_objects_v2 requirements' do
+      let(:requirements_string) { valid_objects_requirements }
 
-        it 'calls validate_custom_objects_v2_requirements but not CustomObjectsV2 module' do
-          expect(ZendeskAppsSupport::Validations::Requirements)
-            .to receive(:validate_custom_objects_v2_requirements).and_call_original
-          expect(ZendeskAppsSupport::Validations::CustomObjectsV2).not_to receive(:call)
-          expect(errors).to be_empty
-        end
-      end
-
-      context 'with excessive custom_objects_v2 requirements' do
-        let(:requirements_string) { excessive_objects_requirements }
-
-        it 'validates max custom object limits' do
-          expect(ZendeskAppsSupport::Validations::Requirements)
-            .to receive(:validate_custom_objects_v2_requirements).and_call_original
-          expect(errors.first.key).to eq(:excessive_custom_objects_v2_requirements)
-          expect(errors.first.data).to eq(max: 50, count: 51)
-        end
-      end
-
-      context 'with valid custom_objects_v2 requirements' do
-        let(:requirements_string) { valid_objects_requirements }
-
-        it 'calls validate_custom_objects_v2_requirements and validates successfully' do
-          expect(ZendeskAppsSupport::Validations::Requirements)
-            .to receive(:validate_custom_objects_v2_requirements).and_call_original
-          expect(ZendeskAppsSupport::Validations::CustomObjectsV2).to receive(:call).and_return([])
-          expect(errors).to be_empty
-        end
+      it 'validates successfully' do
+        expect(ZendeskAppsSupport::Validations::CustomObjectsV2).to receive(:call).and_return([])
+        expect(errors).to be_empty
       end
     end
   end

--- a/spec/validations/requirements_spec.rb
+++ b/spec/validations/requirements_spec.rb
@@ -412,7 +412,7 @@ describe ZendeskAppsSupport::Validations::Requirements do
       let(:requirements_string) { valid_objects_requirements }
 
       it 'validates successfully' do
-        expect(ZendeskAppsSupport::Validations::CustomObjectsV2).to receive(:call).and_return([])
+        expect(ZendeskAppsSupport::Validations::CustomObjectsV2).to receive(:call).and_call_original
         expect(errors).to be_empty
       end
     end


### PR DESCRIPTION
/cc @zendesk/wattle

### Description

The `validate_custom_objects_v2` parameter was used to control whether COV2 requirements validation runs. This was gated by the `apps_cov2_processing` Arturo in `zendesk_app_market`, which is now fully rolled out and stable.

This PR removes the conditional flag so that COV2 validation always runs whenever the `custom_objects_v2` key exists in `requirements.json`.

**Changes:**
- `Package#validate` no longer reads or passes `validate_custom_objects_v2`
- `Validations::Requirements.call` no longer accepts the keyword argument
- `validate_custom_objects_v2_requirements` now only checks if the key is present (no flag check)
- Tests updated to remove flag-based branching (enabled/disabled contexts removed)

Callers that still pass `validate_custom_objects_v2` in their options hash will not break — `Package#validate` uses `options = {}` so unknown keys are silently ignored.

### References

JIRA: https://zendesk.atlassian.net/browse/CRYSTAL-762

#### Before merging this PR
- [x] Fill out the Risks section
- [x] Think about performance and security issues

### Risks

- [low] Apps that have `custom_objects_v2` in their `requirements.json` will now always be validated, regardless of the caller passing the flag. This is the intended behavior since the feature is stable and fully rolled out.