### PR TITLE
feat: Add object_types support for cov2_records_sidebar location

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -305,13 +305,13 @@ en:
             field_cannot_be_empty: "%{field} cannot be empty."
             field_contains_invalid_values: "%{field} contains invalid values: %{values}."
             field_contains_invalid_keys: "%{field} contains invalid keys: %{keys}."
-            object_types_must_be_array: object_types must be an array of strings for
+            object_types_must_be_array: objectTypes must be an array of strings for
               the %{location} location, but it was %{value}.
-            object_types_empty: object_types cannot be empty for the %{location} location.
+            object_types_empty: objectTypes cannot be empty for the %{location} location.
               Specify at least one object type.
-            object_types_invalid_entries: object_types must contain only non-empty
+            object_types_invalid_entries: objectTypes must contain only non-empty
               strings for the %{location} location.
-            object_types_not_supported: object_types is not supported for the %{location}
+            object_types_not_supported: objectTypes is not supported for the %{location}
               location.
         warning:
           app_build:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -268,6 +268,9 @@ en:
                 do not match products in translations (%{translation_products})
               insecure_token_parameter_in_manifest: 'Make sure to set secure to true
                 when using keys in Settings. Learn more: %{link}'
+              password_parameter_deprecated: 'Password parameter type is deprecated
+                and will not be accepted in the future. Use Basic Access Authentication
+                instead. Learn more: %{link}.'
               default_secure_or_hidden_parameter_in_manifest: Default values for secure
                 or hidden parameters are not stored securely. Be sure to review them
                 and confirm they do not contain sensitive data
@@ -295,11 +298,21 @@ en:
             oauth_parameter_cannot_be_secure: oauth parameter cannot be set to be
               secure.
             invalid_url: '%{field} must be a valid URL, got "%{value}".'
+            password_parameter_type_deprecated: 'Password parameter type can no longer
+              be used. Use Secure settings instead. Learn more: %{link}.'
             field_requires_secure_parameter: "%{field} cannot be defined in a non-secure
               parameter."
             field_cannot_be_empty: "%{field} cannot be empty."
             field_contains_invalid_values: "%{field} contains invalid values: %{values}."
             field_contains_invalid_keys: "%{field} contains invalid keys: %{keys}."
+            object_types_must_be_array: object_types must be an array of strings for
+              the %{location} location, but it was %{value}.
+            object_types_empty: object_types cannot be empty for the %{location} location.
+              Specify at least one object type.
+            object_types_invalid_entries: object_types must contain only non-empty
+              strings for the %{location} location.
+            object_types_not_supported: object_types is not supported for the %{location}
+              location.
         warning:
           app_build:
             deprecated_version: You are targeting a deprecated version of the framework.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -300,6 +300,14 @@ en:
             field_cannot_be_empty: "%{field} cannot be empty."
             field_contains_invalid_values: "%{field} contains invalid values: %{values}."
             field_contains_invalid_keys: "%{field} contains invalid keys: %{keys}."
+            object_types_not_supported: object_types is not supported for the %{location}
+              location. It can only be used with cov2_records_sidebar.
+            object_types_must_be_array: object_types must be an array of strings for
+              the %{location} location, but it was %{value}.
+            object_types_empty: object_types cannot be empty for the %{location} location.
+              Specify at least one object type.
+            object_types_invalid_entries: object_types must contain only non-empty strings
+              for the %{location} location.
         warning:
           app_build:
             deprecated_version: You are targeting a deprecated version of the framework.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -313,6 +313,7 @@ en:
               strings for the %{location} location.
             object_types_not_supported: objectTypes is not supported for the %{location}
               location.
+            object_types_required: objectTypes is required for the %{location} location.
         warning:
           app_build:
             deprecated_version: You are targeting a deprecated version of the framework.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -300,14 +300,6 @@ en:
             field_cannot_be_empty: "%{field} cannot be empty."
             field_contains_invalid_values: "%{field} contains invalid values: %{values}."
             field_contains_invalid_keys: "%{field} contains invalid keys: %{keys}."
-            object_types_not_supported: object_types is not supported for the %{location}
-              location. It can only be used with cov2_records_sidebar.
-            object_types_must_be_array: object_types must be an array of strings for
-              the %{location} location, but it was %{value}.
-            object_types_empty: object_types cannot be empty for the %{location} location.
-              Specify at least one object type.
-            object_types_invalid_entries: object_types must contain only non-empty strings
-              for the %{location} location.
         warning:
           app_build:
             deprecated_version: You are targeting a deprecated version of the framework.

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -676,20 +676,20 @@ parts:
       value: "%{field} contains invalid keys: %{keys}."
   - translation:
       key: "txt.apps.admin.error.app_build.object_types_must_be_array"
-      title: "App builder job: object_types must be an array of strings for the given location. Do not translate 'object_types' as it is a manifest property."
-      value: "object_types must be an array of strings for the %{location} location, but it was %{value}."
+      title: "App builder job: objectTypes must be an array of strings for the given location. Do not translate 'objectTypes' as it is a manifest property."
+      value: "objectTypes must be an array of strings for the %{location} location, but it was %{value}."
   - translation:
       key: "txt.apps.admin.error.app_build.object_types_empty"
-      title: "App builder job: object_types cannot be empty for the given location. Do not translate 'object_types' as it is a manifest property."
-      value: "object_types cannot be empty for the %{location} location. Specify at least one object type."
+      title: "App builder job: objectTypes cannot be empty for the given location. Do not translate 'objectTypes' as it is a manifest property."
+      value: "objectTypes cannot be empty for the %{location} location. Specify at least one object type."
   - translation:
       key: "txt.apps.admin.error.app_build.object_types_invalid_entries"
-      title: "App builder job: object_types must contain only non-empty strings for the given location. Do not translate 'object_types' as it is a manifest property."
-      value: "object_types must contain only non-empty strings for the %{location} location."
+      title: "App builder job: objectTypes must contain only non-empty strings for the given location. Do not translate 'objectTypes' as it is a manifest property."
+      value: "objectTypes must contain only non-empty strings for the %{location} location."
   - translation:
       key: "txt.apps.admin.error.app_build.object_types_not_supported"
-      title: "App builder job: object_types is not supported for the given location. Do not translate 'object_types' as it is a manifest property."
-      value: "object_types is not supported for the %{location} location."
+      title: "App builder job: objectTypes is not supported for the given location. Do not translate 'objectTypes' as it is a manifest property."
+      value: "objectTypes is not supported for the %{location} location."
   - translation:
       key: "txt.apps.admin.error.app_build.translation.secure_parameters_with_no_scopes_in_manifest"
       title: "Validation message to indicate missing scopes field in manifest's secure parameter.

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -687,6 +687,10 @@ parts:
       title: "App builder job: object_types must contain only non-empty strings for the given location. Do not translate 'object_types' as it is a manifest property."
       value: "object_types must contain only non-empty strings for the %{location} location."
   - translation:
+      key: "txt.apps.admin.error.app_build.object_types_not_supported"
+      title: "App builder job: object_types is not supported for the given location. Do not translate 'object_types' as it is a manifest property."
+      value: "object_types is not supported for the %{location} location."
+  - translation:
       key: "txt.apps.admin.error.app_build.translation.secure_parameters_with_no_scopes_in_manifest"
       title: "Validation message to indicate missing scopes field in manifest's secure parameter.
         Do not translate 'scopes'. %{params} refers to secure parameters with no scopes configured.

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -691,6 +691,10 @@ parts:
       title: "App builder job: objectTypes is not supported for the given location. Do not translate 'objectTypes' as it is a manifest property."
       value: "objectTypes is not supported for the %{location} location."
   - translation:
+      key: "txt.apps.admin.error.app_build.object_types_required"
+      title: "App builder job: objectTypes is required for the given location. Do not translate 'objectTypes' as it is a manifest property."
+      value: "objectTypes is required for the %{location} location."
+  - translation:
       key: "txt.apps.admin.error.app_build.translation.secure_parameters_with_no_scopes_in_manifest"
       title: "Validation message to indicate missing scopes field in manifest's secure parameter.
         Do not translate 'scopes'. %{params} refers to secure parameters with no scopes configured.

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -675,6 +675,18 @@ parts:
       title: "App builder job: Error for invalid field keys. Placeholder %{field} shows parameter fields like \"parameter[name='param'].scopes\" provided in the supplied manifest file, %{keys} shows the invalid keys found within the field."
       value: "%{field} contains invalid keys: %{keys}."
   - translation:
+      key: "txt.apps.admin.error.app_build.object_types_must_be_array"
+      title: "App builder job: object_types must be an array of strings for the given location. Do not translate 'object_types' as it is a manifest property."
+      value: "object_types must be an array of strings for the %{location} location, but it was %{value}."
+  - translation:
+      key: "txt.apps.admin.error.app_build.object_types_empty"
+      title: "App builder job: object_types cannot be empty for the given location. Do not translate 'object_types' as it is a manifest property."
+      value: "object_types cannot be empty for the %{location} location. Specify at least one object type."
+  - translation:
+      key: "txt.apps.admin.error.app_build.object_types_invalid_entries"
+      title: "App builder job: object_types must contain only non-empty strings for the given location. Do not translate 'object_types' as it is a manifest property."
+      value: "object_types must contain only non-empty strings for the %{location} location."
+  - translation:
       key: "txt.apps.admin.error.app_build.translation.secure_parameters_with_no_scopes_in_manifest"
       title: "Validation message to indicate missing scopes field in manifest's secure parameter.
         Do not translate 'scopes'. %{params} refers to secure parameters with no scopes configured.

--- a/lib/zendesk_apps_support/location.rb
+++ b/lib/zendesk_apps_support/location.rb
@@ -65,7 +65,8 @@ module ZendeskAppsSupport
       Location.new(id: 23, name: 'call_log_editor', product_code: Product::SELL.code, visible: true),
       Location.new(id: 24, name: 'email_editor', product_code: Product::SELL.code, visible: true),
       Location.new(id: 25, name: 'top_bar', product_code: Product::SELL.code, visible: true),
-      Location.new(id: 26, name: 'visit_editor', product_code: Product::SELL.code, visible: true)
+      Location.new(id: 26, name: 'visit_editor', product_code: Product::SELL.code, visible: true),
+      Location.new(id: 27, name: 'cov2_records_sidebar', product_code: Product::SUPPORT.code, visible: true)
     ].freeze
   end
 end

--- a/lib/zendesk_apps_support/location.rb
+++ b/lib/zendesk_apps_support/location.rb
@@ -68,7 +68,7 @@ module ZendeskAppsSupport
       Location.new(id: 24, name: 'email_editor', product_code: Product::SELL.code, visible: true),
       Location.new(id: 25, name: 'top_bar', product_code: Product::SELL.code, visible: true),
       Location.new(id: 26, name: 'visit_editor', product_code: Product::SELL.code, visible: true),
-      Location.new(id: 27, orderable: true, collapsible: true, name: 'custom_object_record_sidebar',
+      Location.new(id: 27, orderable: true, collapsible: true, name: CUSTOM_OBJECT_RECORD_SIDEBAR_LOCATION,
                    product_code: Product::SUPPORT.code, visible: true)
     ].freeze
   end

--- a/lib/zendesk_apps_support/location.rb
+++ b/lib/zendesk_apps_support/location.rb
@@ -5,6 +5,8 @@ module ZendeskAppsSupport
     extend ZendeskAppsSupport::Finders
     attr_reader :id, :name, :orderable, :collapsible, :visible, :product_code, :v2_only
 
+    CUSTOM_OBJECT_RECORD_SIDEBAR_LOCATION = 'custom_object_record_sidebar'
+
     def self.unique_ids
       @ids ||= Set.new
     end
@@ -24,8 +26,6 @@ module ZendeskAppsSupport
     def product
       Product.find_by(code: product_code)
     end
-
-    OBJECT_TYPES_LOCATION = 'cov2_records_sidebar'
 
     def self.all
       LOCATIONS_AVAILABLE
@@ -68,7 +68,7 @@ module ZendeskAppsSupport
       Location.new(id: 24, name: 'email_editor', product_code: Product::SELL.code, visible: true),
       Location.new(id: 25, name: 'top_bar', product_code: Product::SELL.code, visible: true),
       Location.new(id: 26, name: 'visit_editor', product_code: Product::SELL.code, visible: true),
-      Location.new(id: 27, orderable: true, collapsible: true, name: 'cov2_records_sidebar',
+      Location.new(id: 27, orderable: true, collapsible: true, name: 'custom_object_record_sidebar',
                    product_code: Product::SUPPORT.code, visible: true)
     ].freeze
   end

--- a/lib/zendesk_apps_support/location.rb
+++ b/lib/zendesk_apps_support/location.rb
@@ -25,6 +25,8 @@ module ZendeskAppsSupport
       Product.find_by(code: product_code)
     end
 
+    OBJECT_TYPES_LOCATION = 'cov2_records_sidebar'
+
     def self.all
       LOCATIONS_AVAILABLE
     end
@@ -66,7 +68,8 @@ module ZendeskAppsSupport
       Location.new(id: 24, name: 'email_editor', product_code: Product::SELL.code, visible: true),
       Location.new(id: 25, name: 'top_bar', product_code: Product::SELL.code, visible: true),
       Location.new(id: 26, name: 'visit_editor', product_code: Product::SELL.code, visible: true),
-      Location.new(id: 27, name: 'cov2_records_sidebar', product_code: Product::SUPPORT.code, visible: true)
+      Location.new(id: 27, orderable: true, collapsible: true, name: 'cov2_records_sidebar',
+                   product_code: Product::SUPPORT.code, visible: true)
     ].freeze
   end
 end

--- a/lib/zendesk_apps_support/manifest.rb
+++ b/lib/zendesk_apps_support/manifest.rb
@@ -98,7 +98,7 @@ module ZendeskAppsSupport
     end
 
     def locations_for_product(host)
-      locations.key?(host) ? locations[host].keys : []
+      locations.key?(host) ? locations[host].keys.map(&:to_s) : []
     end
 
     def unknown_hosts

--- a/lib/zendesk_apps_support/manifest.rb
+++ b/lib/zendesk_apps_support/manifest.rb
@@ -97,10 +97,6 @@ module ZendeskAppsSupport
       end
     end
 
-    def locations_for_product(host)
-      locations.key?(host) ? locations[host].keys.map(&:to_s) : []
-    end
-
     def unknown_hosts
       @unknown_hosts ||=
         @used_hosts - Product::PRODUCTS_AVAILABLE.flat_map { |p| [p.name, p.legacy_name] }

--- a/lib/zendesk_apps_support/manifest.rb
+++ b/lib/zendesk_apps_support/manifest.rb
@@ -97,6 +97,10 @@ module ZendeskAppsSupport
       end
     end
 
+    def locations_for_product(host)
+      locations.key?(host) ? locations[host].keys : []
+    end
+
     def unknown_hosts
       @unknown_hosts ||=
         @used_hosts - Product::PRODUCTS_AVAILABLE.flat_map { |p| [p.name, p.legacy_name] }

--- a/lib/zendesk_apps_support/manifest/location_options.rb
+++ b/lib/zendesk_apps_support/manifest/location_options.rb
@@ -11,7 +11,7 @@ module ZendeskAppsSupport
         signed: 'signed',
         url: 'url',
         size: 'size',
-        object_types: 'object_types'
+        object_types: 'objectTypes'
       }.freeze
 
       OBJECT_TYPES_LOCATION = 'cov2_records_sidebar'

--- a/lib/zendesk_apps_support/manifest/location_options.rb
+++ b/lib/zendesk_apps_support/manifest/location_options.rb
@@ -10,8 +10,11 @@ module ZendeskAppsSupport
         flexible: 'flexible',
         signed: 'signed',
         url: 'url',
-        size: 'size'
+        size: 'size',
+        object_types: 'object_types'
       }.freeze
+
+      OBJECT_TYPES_LOCATION = 'cov2_records_sidebar'
 
       attr_reader :location
       attr_reader(*RUBY_TO_JSON.keys)
@@ -31,6 +34,7 @@ module ZendeskAppsSupport
         @auto_load = options.fetch('autoLoad', true)
         @auto_hide ||= false
         @signed ||= false
+        @object_types = nil unless @location&.name == OBJECT_TYPES_LOCATION
       end
     end
   end

--- a/lib/zendesk_apps_support/manifest/location_options.rb
+++ b/lib/zendesk_apps_support/manifest/location_options.rb
@@ -14,8 +14,6 @@ module ZendeskAppsSupport
         object_types: 'objectTypes'
       }.freeze
 
-      OBJECT_TYPES_LOCATION = 'cov2_records_sidebar'
-
       attr_reader :location
       attr_reader(*RUBY_TO_JSON.keys)
 
@@ -34,7 +32,6 @@ module ZendeskAppsSupport
         @auto_load = options.fetch('autoLoad', true)
         @auto_hide ||= false
         @signed ||= false
-        @object_types = nil unless @location&.name == OBJECT_TYPES_LOCATION
       end
     end
   end

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -12,9 +12,9 @@ module ZendeskAppsSupport
     MANIFEST_FILENAME = 'manifest.json'
     REQUIREMENTS_FILENAME = 'requirements.json'
 
-    DEFAULT_LAYOUT = Erubis::Eruby.new(File.read(File.expand_path('assets/default_template.html.erb', __dir__)))
-    DEFAULT_SCSS   = File.read(File.expand_path('assets/default_styles.scss', __dir__))
-    SRC_TEMPLATE   = Erubis::Eruby.new(File.read(File.expand_path('assets/src.js.erb', __dir__)))
+    DEFAULT_LAYOUT = Erubis::Eruby.new(File.read(File.expand_path('../assets/default_template.html.erb', __FILE__)))
+    DEFAULT_SCSS   = File.read(File.expand_path('../assets/default_styles.scss', __FILE__))
+    SRC_TEMPLATE   = Erubis::Eruby.new(File.read(File.expand_path('../assets/src.js.erb', __FILE__)))
 
     LOCATIONS_WITH_ICONS_PER_PRODUCT = {
       Product::SUPPORT => %w[top_bar nav_bar system_top_bar ticket_editor].freeze,

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -12,9 +12,9 @@ module ZendeskAppsSupport
     MANIFEST_FILENAME = 'manifest.json'
     REQUIREMENTS_FILENAME = 'requirements.json'
 
-    DEFAULT_LAYOUT = Erubis::Eruby.new(File.read(File.expand_path('../assets/default_template.html.erb', __FILE__)))
-    DEFAULT_SCSS   = File.read(File.expand_path('../assets/default_styles.scss', __FILE__))
-    SRC_TEMPLATE   = Erubis::Eruby.new(File.read(File.expand_path('../assets/src.js.erb', __FILE__)))
+    DEFAULT_LAYOUT = Erubis::Eruby.new(File.read(File.expand_path('assets/default_template.html.erb', __dir__)))
+    DEFAULT_SCSS   = File.read(File.expand_path('assets/default_styles.scss', __dir__))
+    SRC_TEMPLATE   = Erubis::Eruby.new(File.read(File.expand_path('assets/src.js.erb', __dir__)))
 
     LOCATIONS_WITH_ICONS_PER_PRODUCT = {
       Product::SUPPORT => %w[top_bar nav_bar system_top_bar ticket_editor].freeze,
@@ -34,9 +34,10 @@ module ZendeskAppsSupport
     def validate(options = {})
       marketplace = options.fetch(:marketplace, true)
       skip_marketplace_translations = options.fetch(:skip_marketplace_translations, false)
+      is_cov2_sidebar_app_enabled = options.fetch(:is_cov2_sidebar_app_enabled, false)
 
       errors = []
-      errors << Validations::Manifest.call(self)
+      errors << Validations::Manifest.call(self, is_cov2_sidebar_app_enabled:)
 
       if has_valid_manifest?(errors)
         errors << Validations::Marketplace.call(self) if marketplace

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -34,11 +34,10 @@ module ZendeskAppsSupport
     def validate(options = {})
       marketplace = options.fetch(:marketplace, true)
       skip_marketplace_translations = options.fetch(:skip_marketplace_translations, false)
-      validate_custom_object_sidebar = options.fetch(:validate_custom_object_record_sidebar_location, false)
+      validate_custom_object_record_sidebar_location = options.fetch(:validate_custom_object_record_sidebar_location, false)
 
       errors = []
-      manifest_opts = { validate_custom_object_record_sidebar_location: validate_custom_object_sidebar }
-      errors << Validations::Manifest.call(self, manifest_opts)
+      errors << Validations::Manifest.call(self, validate_custom_object_record_sidebar_location: validate_custom_object_record_sidebar_location)
 
       if has_valid_manifest?(errors)
         errors << Validations::Marketplace.call(self) if marketplace

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -34,10 +34,11 @@ module ZendeskAppsSupport
     def validate(options = {})
       marketplace = options.fetch(:marketplace, true)
       skip_marketplace_translations = options.fetch(:skip_marketplace_translations, false)
-      is_cov2_sidebar_app_enabled = options.fetch(:is_cov2_sidebar_app_enabled, false)
+      validate_custom_object_sidebar = options.fetch(:validate_custom_object_record_sidebar_location, false)
 
       errors = []
-      errors << Validations::Manifest.call(self, is_cov2_sidebar_app_enabled:)
+      manifest_opts = { validate_custom_object_record_sidebar_location: validate_custom_object_sidebar }
+      errors << Validations::Manifest.call(self, manifest_opts)
 
       if has_valid_manifest?(errors)
         errors << Validations::Marketplace.call(self) if marketplace

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -14,7 +14,7 @@ module ZendeskAppsSupport
       SECURE_PARAM_SCOPES = %w[header body url jwt_secret_key jwt_claim basic_auth_username basic_auth_password].freeze
 
       class << self
-        def call(package)
+        def call(package, opts = {})
           unless package.has_file?('manifest.json')
             nested_manifest = package.files.find { |file| file =~ %r{\A[^/]+?/manifest\.json\Z} }
             if nested_manifest
@@ -22,7 +22,7 @@ module ZendeskAppsSupport
             end
             return [ValidationError.new(:missing_manifest)]
           end
-          collate_manifest_errors(package)
+          collate_manifest_errors(package, opts)
         rescue JSON::ParserError => e
           return [ValidationError.new(:manifest_not_json, errors: e)]
         rescue ZendeskAppsSupport::Manifest::OverrideError => e
@@ -31,7 +31,7 @@ module ZendeskAppsSupport
 
         private
 
-        def collate_manifest_errors(package)
+        def collate_manifest_errors(package, opts = {})
           manifest = package.manifest
 
           errors = [
@@ -45,7 +45,7 @@ module ZendeskAppsSupport
               [ ban_location(manifest),
                 ban_framework_version(manifest) ]
             else
-              [ validate_location(package),
+              [ validate_location(package, opts),
                 missing_framework_version(manifest),
                 invalid_version_error(manifest) ]
             end,
@@ -54,14 +54,14 @@ module ZendeskAppsSupport
           errors.flatten.compact
         end
 
-        def validate_location(package)
+        def validate_location(package, opts = {})
           manifest = package.manifest
           [
             missing_location_error(package),
-            invalid_location_error(package),
+            invalid_location_error(package, opts),
             invalid_v1_location(package),
             location_framework_mismatch(manifest),
-            validate_object_types(manifest)
+            validate_object_types(manifest, opts)
           ]
         end
 
@@ -314,8 +314,11 @@ module ZendeskAppsSupport
           missing_keys_validation_error(['location']) if package.manifest.location_options.empty?
         end
 
-        def invalid_location_error(package)
+        def invalid_location_error(package, opts = {})
           errors = []
+          is_cov2_sidebar_app_enabled = opts.fetch(:is_cov2_sidebar_app_enabled, false)
+          cov2_location = ZendeskAppsSupport::Manifest::LocationOptions::OBJECT_TYPES_LOCATION
+
           package.manifest.location_options.each do |location_options|
             if location_options.url.is_a?(String) && !location_options.url.empty?
               errors << invalid_location_uri_error(package, location_options)
@@ -330,6 +333,12 @@ module ZendeskAppsSupport
 
           Product::PRODUCTS_AVAILABLE.each do |product|
             invalid_locations = package.manifest.unknown_locations(product.name)
+            unless is_cov2_sidebar_app_enabled
+              requested_locations = package.manifest.locations_for_product(product.name)
+              if requested_locations.include?(cov2_location)
+                invalid_locations << cov2_location
+              end
+            end
             next if invalid_locations.empty?
             errors << ValidationError.new(:invalid_location,
                                           invalid_locations: invalid_locations.join(', '),
@@ -380,13 +389,21 @@ module ZendeskAppsSupport
           validation_error
         end
 
-        def validate_object_types(manifest)
+        def validate_object_types(manifest, opts = {})
+          is_cov2_sidebar_app_enabled = opts.fetch(:is_cov2_sidebar_app_enabled, false)
+          cov2_location = ZendeskAppsSupport::Manifest::LocationOptions::OBJECT_TYPES_LOCATION
+
           manifest.location_options.each do |location_options|
             object_types = location_options.object_types
             next if object_types.nil?
             next if location_options.location.nil?
 
             location_name = location_options.location.name
+
+            if location_name == cov2_location && !is_cov2_sidebar_app_enabled
+              return ValidationError.new(:object_types_not_supported,
+                                         location: location_name)
+            end
 
             unless object_types.is_a?(Array)
               return ValidationError.new(:object_types_must_be_array,

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -316,8 +316,8 @@ module ZendeskAppsSupport
 
         def invalid_location_error(package, opts = {})
           errors = []
-          is_cov2_sidebar_app_enabled = opts.fetch(:is_cov2_sidebar_app_enabled, false)
-          cov2_location = ZendeskAppsSupport::Location::OBJECT_TYPES_LOCATION
+          validate_custom_object_record_sidebar = opts.fetch(:validate_custom_object_record_sidebar_location, false)
+          custom_object_record_sidebar = ZendeskAppsSupport::Location::CUSTOM_OBJECT_RECORD_SIDEBAR_LOCATION
 
           package.manifest.location_options.each do |location_options|
             if location_options.url.is_a?(String) && !location_options.url.empty?
@@ -333,12 +333,16 @@ module ZendeskAppsSupport
 
           Product::PRODUCTS_AVAILABLE.each do |product|
             invalid_locations = package.manifest.unknown_locations(product.name)
-            unless is_cov2_sidebar_app_enabled
-              requested_locations = package.manifest.locations_for_product(product.name)
-              if requested_locations.include?(cov2_location)
-                invalid_locations << cov2_location
+
+            unless validate_custom_object_record_sidebar
+              requested_locations = package.manifest.location_options
+                                           .select { |lo| lo.location&.product_code == product.code }
+                                           .map { |lo| lo.location&.name }
+              if requested_locations.include?(custom_object_record_sidebar)
+                invalid_locations << custom_object_record_sidebar
               end
             end
+
             next if invalid_locations.empty?
             errors << ValidationError.new(:invalid_location,
                                           invalid_locations: invalid_locations.join(', '),
@@ -390,22 +394,24 @@ module ZendeskAppsSupport
         end
 
         def validate_object_types(manifest, opts = {})
-          is_cov2_sidebar_app_enabled = opts.fetch(:is_cov2_sidebar_app_enabled, false)
-          cov2_location = ZendeskAppsSupport::Location::OBJECT_TYPES_LOCATION
+          return nil unless opts.fetch(:validate_custom_object_record_sidebar_location, false)
 
+          custom_object_record_sidebar = ZendeskAppsSupport::Location::CUSTOM_OBJECT_RECORD_SIDEBAR_LOCATION
           manifest.location_options.each do |location_options|
             object_types = location_options.object_types
-            next if object_types.nil?
             next if location_options.location.nil?
 
             location_name = location_options.location.name
 
-            if location_name != cov2_location
-              return ValidationError.new(:object_types_not_supported,
-                                         location: location_name)
+            if object_types.nil?
+              if location_name == custom_object_record_sidebar
+                return ValidationError.new(:object_types_required,
+                                           location: location_name)
+              end
+              next
             end
 
-            if location_name == cov2_location && !is_cov2_sidebar_app_enabled
+            if location_name != custom_object_record_sidebar
               return ValidationError.new(:object_types_not_supported,
                                          location: location_name)
             end

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -60,7 +60,8 @@ module ZendeskAppsSupport
             missing_location_error(package),
             invalid_location_error(package),
             invalid_v1_location(package),
-            location_framework_mismatch(manifest)
+            location_framework_mismatch(manifest),
+            validate_object_types(manifest)
           ]
         end
 
@@ -377,6 +378,42 @@ module ZendeskAppsSupport
           flexible_flag = location_options.flexible
           validation_error = ValidationError.new(:invalid_location_flexible_type, flexible: flexible_flag)
           validation_error
+        end
+
+        def validate_object_types(manifest)
+          errors = []
+          manifest.location_options.each do |location_options|
+            object_types = location_options.object_types
+            next if object_types.nil?
+            next if location_options.location.nil?
+
+            location_name = location_options.location.name
+            if location_name != ZendeskAppsSupport::Manifest::LocationOptions::OBJECT_TYPES_LOCATION
+              errors << ValidationError.new(:object_types_not_supported,
+                                            location: location_name)
+              next
+            end
+
+            unless object_types.is_a?(Array)
+              errors << ValidationError.new(:object_types_must_be_array,
+                                            location: location_name,
+                                            value: object_types.class.to_s)
+              next
+            end
+
+            if object_types.empty?
+              errors << ValidationError.new(:object_types_empty,
+                                            location: location_name)
+              next
+            end
+
+            non_strings = object_types.reject { |t| t.is_a?(String) && !t.strip.empty? }
+            if non_strings.any?
+              errors << ValidationError.new(:object_types_invalid_entries,
+                                            location: location_name)
+            end
+          end
+          errors
         end
 
         def valid_absolute_uri?(uri)

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -417,7 +417,7 @@ module ZendeskAppsSupport
             end
 
             non_strings = object_types.reject { |t| t.is_a?(String) && !t.strip.empty? }
-            if non_strings.any?
+            unless non_strings.empty?
               return ValidationError.new(:object_types_invalid_entries,
                                          location: location_name)
             end

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -317,7 +317,7 @@ module ZendeskAppsSupport
         def invalid_location_error(package, opts = {})
           errors = []
           is_cov2_sidebar_app_enabled = opts.fetch(:is_cov2_sidebar_app_enabled, false)
-          cov2_location = ZendeskAppsSupport::Manifest::LocationOptions::OBJECT_TYPES_LOCATION
+          cov2_location = ZendeskAppsSupport::Location::OBJECT_TYPES_LOCATION
 
           package.manifest.location_options.each do |location_options|
             if location_options.url.is_a?(String) && !location_options.url.empty?
@@ -391,7 +391,7 @@ module ZendeskAppsSupport
 
         def validate_object_types(manifest, opts = {})
           is_cov2_sidebar_app_enabled = opts.fetch(:is_cov2_sidebar_app_enabled, false)
-          cov2_location = ZendeskAppsSupport::Manifest::LocationOptions::OBJECT_TYPES_LOCATION
+          cov2_location = ZendeskAppsSupport::Location::OBJECT_TYPES_LOCATION
 
           manifest.location_options.each do |location_options|
             object_types = location_options.object_types
@@ -399,6 +399,11 @@ module ZendeskAppsSupport
             next if location_options.location.nil?
 
             location_name = location_options.location.name
+
+            if location_name != cov2_location
+              return ValidationError.new(:object_types_not_supported,
+                                         location: location_name)
+            end
 
             if location_name == cov2_location && !is_cov2_sidebar_app_enabled
               return ValidationError.new(:object_types_not_supported,

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -381,39 +381,30 @@ module ZendeskAppsSupport
         end
 
         def validate_object_types(manifest)
-          errors = []
           manifest.location_options.each do |location_options|
             object_types = location_options.object_types
             next if object_types.nil?
             next if location_options.location.nil?
 
             location_name = location_options.location.name
-            if location_name != ZendeskAppsSupport::Manifest::LocationOptions::OBJECT_TYPES_LOCATION
-              errors << ValidationError.new(:object_types_not_supported,
-                                            location: location_name)
-              next
-            end
 
             unless object_types.is_a?(Array)
-              errors << ValidationError.new(:object_types_must_be_array,
-                                            location: location_name,
-                                            value: object_types.class.to_s)
-              next
+              return ValidationError.new(:object_types_must_be_array,
+                                         location: location_name,
+                                         value: object_types.class.to_s)
             end
 
             if object_types.empty?
-              errors << ValidationError.new(:object_types_empty,
-                                            location: location_name)
-              next
+              return ValidationError.new(:object_types_empty,
+                                         location: location_name)
             end
 
             non_strings = object_types.reject { |t| t.is_a?(String) && !t.strip.empty? }
             if non_strings.any?
-              errors << ValidationError.new(:object_types_invalid_entries,
-                                            location: location_name)
+              return ValidationError.new(:object_types_invalid_entries,
+                                         location: location_name)
             end
           end
-          errors
         end
 
         def valid_absolute_uri?(uri)

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -405,6 +405,7 @@ module ZendeskAppsSupport
                                          location: location_name)
             end
           end
+          nil
         end
 
         def valid_absolute_uri?(uri)

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -14,7 +14,7 @@ module ZendeskAppsSupport
       SECURE_PARAM_SCOPES = %w[header body url jwt_secret_key jwt_claim basic_auth_username basic_auth_password].freeze
 
       class << self
-        def call(package, opts = {})
+        def call(package, validate_custom_object_record_sidebar_location: false)
           unless package.has_file?('manifest.json')
             nested_manifest = package.files.find { |file| file =~ %r{\A[^/]+?/manifest\.json\Z} }
             if nested_manifest
@@ -22,7 +22,8 @@ module ZendeskAppsSupport
             end
             return [ValidationError.new(:missing_manifest)]
           end
-          collate_manifest_errors(package, opts)
+          collate_manifest_errors(package,
+                                  validate_custom_object_record_sidebar_location: validate_custom_object_record_sidebar_location)
         rescue JSON::ParserError => e
           return [ValidationError.new(:manifest_not_json, errors: e)]
         rescue ZendeskAppsSupport::Manifest::OverrideError => e
@@ -31,7 +32,7 @@ module ZendeskAppsSupport
 
         private
 
-        def collate_manifest_errors(package, opts = {})
+        def collate_manifest_errors(package, validate_custom_object_record_sidebar_location: false)
           manifest = package.manifest
 
           errors = [
@@ -45,7 +46,8 @@ module ZendeskAppsSupport
               [ ban_location(manifest),
                 ban_framework_version(manifest) ]
             else
-              [ validate_location(package, opts),
+              [ validate_location(package,
+                                  validate_custom_object_record_sidebar_location: validate_custom_object_record_sidebar_location),
                 missing_framework_version(manifest),
                 invalid_version_error(manifest) ]
             end,
@@ -54,14 +56,15 @@ module ZendeskAppsSupport
           errors.flatten.compact
         end
 
-        def validate_location(package, opts = {})
+        def validate_location(package, validate_custom_object_record_sidebar_location: false)
           manifest = package.manifest
           [
             missing_location_error(package),
-            invalid_location_error(package, opts),
+            invalid_location_error(package,
+                                   validate_custom_object_record_sidebar_location: validate_custom_object_record_sidebar_location),
             invalid_v1_location(package),
             location_framework_mismatch(manifest),
-            validate_object_types(manifest, opts)
+            (validate_object_types(manifest) if validate_custom_object_record_sidebar_location)
           ]
         end
 
@@ -314,9 +317,8 @@ module ZendeskAppsSupport
           missing_keys_validation_error(['location']) if package.manifest.location_options.empty?
         end
 
-        def invalid_location_error(package, opts = {})
+        def invalid_location_error(package, validate_custom_object_record_sidebar_location: false)
           errors = []
-          validate_custom_object_record_sidebar = opts.fetch(:validate_custom_object_record_sidebar_location, false)
           custom_object_record_sidebar = ZendeskAppsSupport::Location::CUSTOM_OBJECT_RECORD_SIDEBAR_LOCATION
 
           package.manifest.location_options.each do |location_options|
@@ -334,7 +336,7 @@ module ZendeskAppsSupport
           Product::PRODUCTS_AVAILABLE.each do |product|
             invalid_locations = package.manifest.unknown_locations(product.name)
 
-            unless validate_custom_object_record_sidebar
+            unless validate_custom_object_record_sidebar_location
               requested_locations = package.manifest.location_options
                                            .select { |lo| lo.location&.product_code == product.code }
                                            .map { |lo| lo.location&.name }
@@ -393,9 +395,7 @@ module ZendeskAppsSupport
           validation_error
         end
 
-        def validate_object_types(manifest, opts = {})
-          return nil unless opts.fetch(:validate_custom_object_record_sidebar_location, false)
-
+        def validate_object_types(manifest)
           custom_object_record_sidebar = ZendeskAppsSupport::Location::CUSTOM_OBJECT_RECORD_SIDEBAR_LOCATION
           manifest.location_options.each do |location_options|
             object_types = location_options.object_types

--- a/spec/manifest/location_options_spec.rb
+++ b/spec/manifest/location_options_spec.rb
@@ -43,7 +43,7 @@ describe ZendeskAppsSupport::Manifest::LocationOptions do
   context 'with object_types' do
     let(:location) do
       ZendeskAppsSupport::Location::LOCATIONS_AVAILABLE.find do |l|
-        l.name == described_class::OBJECT_TYPES_LOCATION
+        l.name == ZendeskAppsSupport::Location::OBJECT_TYPES_LOCATION
       end
     end
     let(:options) do
@@ -64,8 +64,8 @@ describe ZendeskAppsSupport::Manifest::LocationOptions do
       }
     end
 
-    it 'ignores object_types' do
-      expect(location_options.object_types).to be_nil
+    it 'preserves object_types for validation' do
+      expect(location_options.object_types).to eq(%w[car truck])
     end
   end
 end

--- a/spec/manifest/location_options_spec.rb
+++ b/spec/manifest/location_options_spec.rb
@@ -48,7 +48,7 @@ describe ZendeskAppsSupport::Manifest::LocationOptions do
     end
     let(:options) do
       {
-        'object_types' => %w[car truck]
+        'objectTypes' => %w[car truck]
       }
     end
 
@@ -60,7 +60,7 @@ describe ZendeskAppsSupport::Manifest::LocationOptions do
   context 'with object_types on a non-cov2_records_sidebar location' do
     let(:options) do
       {
-        'object_types' => %w[car truck]
+        'objectTypes' => %w[car truck]
       }
     end
 

--- a/spec/manifest/location_options_spec.rb
+++ b/spec/manifest/location_options_spec.rb
@@ -43,7 +43,7 @@ describe ZendeskAppsSupport::Manifest::LocationOptions do
   context 'with object_types' do
     let(:location) do
       ZendeskAppsSupport::Location::LOCATIONS_AVAILABLE.find do |l|
-        l.name == ZendeskAppsSupport::Location::OBJECT_TYPES_LOCATION
+        l.name == ZendeskAppsSupport::Location::CUSTOM_OBJECT_RECORD_SIDEBAR_LOCATION
       end
     end
     let(:options) do
@@ -57,7 +57,7 @@ describe ZendeskAppsSupport::Manifest::LocationOptions do
     end
   end
 
-  context 'with object_types on a non-cov2_records_sidebar location' do
+  context 'with object_types on a non-custom_object_record_sidebar location' do
     let(:options) do
       {
         'objectTypes' => %w[car truck]

--- a/spec/manifest/location_options_spec.rb
+++ b/spec/manifest/location_options_spec.rb
@@ -36,6 +36,36 @@ describe ZendeskAppsSupport::Manifest::LocationOptions do
       expect(location_options.auto_hide).to be false
       expect(location_options.signed).to be false
       expect(location_options.legacy).to be false
+      expect(location_options.object_types).to be_nil
+    end
+  end
+
+  context 'with object_types' do
+    let(:location) do
+      ZendeskAppsSupport::Location::LOCATIONS_AVAILABLE.find do |l|
+        l.name == described_class::OBJECT_TYPES_LOCATION
+      end
+    end
+    let(:options) do
+      {
+        'object_types' => %w[car truck]
+      }
+    end
+
+    it 'reads object_types correctly' do
+      expect(location_options.object_types).to eq(%w[car truck])
+    end
+  end
+
+  context 'with object_types on a non-cov2_records_sidebar location' do
+    let(:options) do
+      {
+        'object_types' => %w[car truck]
+      }
+    end
+
+    it 'ignores object_types' do
+      expect(location_options.object_types).to be_nil
     end
   end
 end

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -405,6 +405,38 @@ describe ZendeskAppsSupport::Manifest do
     end
   end
 
+  describe '#locations_for_product' do
+    it 'returns location names as strings for a known product' do
+      manifest_hash[:location] = {
+        support: {
+          ticket_sidebar: { url: 'https://example.com' },
+          top_bar: { url: 'https://example.com' }
+        }
+      }
+      expect(manifest.locations_for_product('support')).to match_array(%w[ticket_sidebar top_bar])
+    end
+
+    it 'returns an empty array for a product not in the manifest' do
+      manifest_hash[:location] = {
+        support: { ticket_sidebar: { url: 'https://example.com' } }
+      }
+      expect(manifest.locations_for_product('chat')).to eq([])
+    end
+
+    it 'returns an empty array when locations is nil' do
+      manifest_hash.delete(:location)
+      expect(manifest.locations_for_product('chat')).to eq([])
+    end
+
+    it 'returns string keys even when the original keys are symbols' do
+      manifest_hash[:location] = {
+        support: { ticket_sidebar: 'https://example.com' }
+      }
+      result = manifest.locations_for_product('support')
+      expect(result).to all(be_a(String))
+    end
+  end
+
   describe '#iframe_only?' do
     it 'returns false for an app that has a nil framework version' do
       manifest_hash[:frameworkVersion] = nil

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -162,7 +162,7 @@ describe ZendeskAppsSupport::Manifest do
     before do
       manifest_hash[:location] = {
         support: {
-          ZendeskAppsSupport::Manifest::LocationOptions::OBJECT_TYPES_LOCATION.to_sym => {
+          ZendeskAppsSupport::Location::OBJECT_TYPES_LOCATION.to_sym => {
             objectTypes: object_types
           }
         }
@@ -171,7 +171,7 @@ describe ZendeskAppsSupport::Manifest do
 
     it 'parses object_types from location options' do
       lo = manifest.location_options.find do |l|
-        l.location&.name == ZendeskAppsSupport::Manifest::LocationOptions::OBJECT_TYPES_LOCATION
+        l.location&.name == ZendeskAppsSupport::Location::OBJECT_TYPES_LOCATION
       end
       expect(lo.object_types).to eq(object_types)
     end

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -157,7 +157,7 @@ describe ZendeskAppsSupport::Manifest do
   end
 
   describe '#location_options with object_types' do
-    let(:object_types) { Array.new(2) { Faker::Lorem.word } }
+    let(:object_types) { %w[car truck] }
 
     before do
       manifest_hash[:location] = {

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -162,7 +162,7 @@ describe ZendeskAppsSupport::Manifest do
     before do
       manifest_hash[:location] = {
         support: {
-          ZendeskAppsSupport::Location::OBJECT_TYPES_LOCATION.to_sym => {
+          ZendeskAppsSupport::Location::CUSTOM_OBJECT_RECORD_SIDEBAR_LOCATION.to_sym => {
             objectTypes: object_types
           }
         }
@@ -171,7 +171,7 @@ describe ZendeskAppsSupport::Manifest do
 
     it 'parses object_types from location options' do
       lo = manifest.location_options.find do |l|
-        l.location&.name == ZendeskAppsSupport::Location::OBJECT_TYPES_LOCATION
+        l.location&.name == ZendeskAppsSupport::Location::CUSTOM_OBJECT_RECORD_SIDEBAR_LOCATION
       end
       expect(lo.object_types).to eq(object_types)
     end
@@ -402,38 +402,6 @@ describe ZendeskAppsSupport::Manifest do
     it 'raises an error for duplicate locations' do
       manifest_hash[:location] = %w[background background]
       expect { manifest.send(:locations) }.to raise_error(/Duplicate reference in manifest: "background"/)
-    end
-  end
-
-  describe '#locations_for_product' do
-    it 'returns location names as strings for a known product' do
-      manifest_hash[:location] = {
-        support: {
-          ticket_sidebar: { url: 'https://example.com' },
-          top_bar: { url: 'https://example.com' }
-        }
-      }
-      expect(manifest.locations_for_product('support')).to match_array(%w[ticket_sidebar top_bar])
-    end
-
-    it 'returns an empty array for a product not in the manifest' do
-      manifest_hash[:location] = {
-        support: { ticket_sidebar: { url: 'https://example.com' } }
-      }
-      expect(manifest.locations_for_product('chat')).to eq([])
-    end
-
-    it 'returns an empty array when locations is nil' do
-      manifest_hash.delete(:location)
-      expect(manifest.locations_for_product('chat')).to eq([])
-    end
-
-    it 'returns string keys even when the original keys are symbols' do
-      manifest_hash[:location] = {
-        support: { ticket_sidebar: 'https://example.com' }
-      }
-      result = manifest.locations_for_product('support')
-      expect(result).to all(be_a(String))
     end
   end
 

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -163,7 +163,7 @@ describe ZendeskAppsSupport::Manifest do
       manifest_hash[:location] = {
         support: {
           ZendeskAppsSupport::Manifest::LocationOptions::OBJECT_TYPES_LOCATION.to_sym => {
-            object_types: object_types
+            objectTypes: object_types
           }
         }
       }

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -156,6 +156,27 @@ describe ZendeskAppsSupport::Manifest do
     end
   end
 
+  describe '#location_options with object_types' do
+    let(:object_types) { Array.new(2) { Faker::Lorem.word } }
+
+    before do
+      manifest_hash[:location] = {
+        support: {
+          ZendeskAppsSupport::Manifest::LocationOptions::OBJECT_TYPES_LOCATION.to_sym => {
+            object_types: object_types
+          }
+        }
+      }
+    end
+
+    it 'parses object_types from location options' do
+      lo = manifest.location_options.find do |l|
+        l.location&.name == ZendeskAppsSupport::Manifest::LocationOptions::OBJECT_TYPES_LOCATION
+      end
+      expect(lo.object_types).to eq(object_types)
+    end
+  end
+
   describe '#no_template?' do
     context 'when noTemplate is a boolean in the manifest' do
       it 'returns true when noTemplate is true' do

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -848,7 +848,7 @@ describe ZendeskAppsSupport::Validations::Manifest do
       let(:location_name) { 'ticket_sidebar' }
 
       it 'should silently ignore object_types' do
-        expect(create_package(@manifest_hash)).not_to have_error(:object_types_not_supported)
+        expect(create_package(@manifest_hash)).not_to have_error
       end
     end
   end

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -812,9 +812,6 @@ describe ZendeskAppsSupport::Validations::Manifest do
     let(:location_url) { 'https://example.com/app' }
     let(:location_opts) { { 'url' => location_url, 'objectTypes' => object_types } }
     let(:object_types) { %w[car truck] }
-    let(:enabled_opts) { { validate_custom_object_record_sidebar_location: true } }
-    let(:disabled_opts) { { validate_custom_object_record_sidebar_location: false } }
-
     before do
       @manifest_hash = {
         'location' => {
@@ -825,9 +822,9 @@ describe ZendeskAppsSupport::Validations::Manifest do
       }
     end
 
-    context 'when flag is enabled' do
+    context 'when validate_custom_object_record_sidebar_location is true' do
       def validate(package)
-        ZendeskAppsSupport::Validations::Manifest.call(package, enabled_opts)
+        ZendeskAppsSupport::Validations::Manifest.call(package, validate_custom_object_record_sidebar_location: true)
       end
 
       context 'with custom_object_record_sidebar location' do
@@ -923,9 +920,9 @@ describe ZendeskAppsSupport::Validations::Manifest do
       end
     end
 
-    context 'when flag is disabled' do
+    context 'when validate_custom_object_record_sidebar_location is false' do
       def validate(package)
-        ZendeskAppsSupport::Validations::Manifest.call(package, disabled_opts)
+        ZendeskAppsSupport::Validations::Manifest.call(package, validate_custom_object_record_sidebar_location: false)
       end
 
       context 'with custom_object_record_sidebar location' do

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -879,6 +879,66 @@ describe ZendeskAppsSupport::Validations::Manifest do
         expect(create_package(@manifest_hash)).not_to have_error
       end
     end
+
+    context 'edge cases for object_types entries' do
+      def validate_with_cov2_enabled(package)
+        ZendeskAppsSupport::Validations::Manifest.call(package, is_cov2_sidebar_app_enabled: true)
+      end
+
+      it 'should have an error when object_types contains whitespace-only strings' do
+        @manifest_hash['location']['support'][location_name]['objectTypes'] = ['car', '   ']
+        create_package(@manifest_hash)
+        errors = validate_with_cov2_enabled(@package)
+        expect(errors.find { |e| e.key == :object_types_invalid_entries }).not_to be_nil
+      end
+
+      it 'should have an error when object_types contains nil values' do
+        @manifest_hash['location']['support'][location_name]['objectTypes'] = ['car', nil]
+        create_package(@manifest_hash)
+        errors = validate_with_cov2_enabled(@package)
+        expect(errors.find { |e| e.key == :object_types_invalid_entries }).not_to be_nil
+      end
+
+      it 'should have an error when object_types contains numeric values' do
+        @manifest_hash['location']['support'][location_name]['objectTypes'] = [42]
+        create_package(@manifest_hash)
+        errors = validate_with_cov2_enabled(@package)
+        expect(errors.find { |e| e.key == :object_types_invalid_entries }).not_to be_nil
+      end
+
+      it 'should not have an error with a single valid object_type' do
+        @manifest_hash['location']['support'][location_name]['objectTypes'] = ['car']
+        create_package(@manifest_hash)
+        errors = validate_with_cov2_enabled(@package)
+        expect(errors).to be_empty
+      end
+    end
+
+    context 'cov2_records_sidebar reported as invalid_location when flag is false' do
+      it 'should include cov2_records_sidebar in invalid locations' do
+        create_package(@manifest_hash)
+        errors = ZendeskAppsSupport::Validations::Manifest.call(@package, is_cov2_sidebar_app_enabled: false)
+        invalid_loc_error = errors.find { |e| e.key == :invalid_location }
+        expect(invalid_loc_error).not_to be_nil
+      end
+    end
+
+    context 'full opts passthrough with cov2 enabled' do
+      it 'should have no errors when cov2 is enabled with valid object_types and all required fields' do
+        @manifest_hash = default_required_params(
+          'location' => {
+            'support' => {
+              location_name => {
+                'url' => 'https://example.com/app',
+                'objectTypes' => %w[car truck]
+              }
+            }
+          }
+        )
+        errors = ZendeskAppsSupport::Validations::Manifest.call(@package, is_cov2_sidebar_app_enabled: true)
+        expect(errors).to be_empty
+      end
+    end
   end
 
   context 'scope parameter validations' do

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -807,6 +807,52 @@ describe ZendeskAppsSupport::Validations::Manifest do
     end
   end
 
+  context 'object_types validations' do
+    let(:location_name) { ZendeskAppsSupport::Manifest::LocationOptions::OBJECT_TYPES_LOCATION }
+    let(:location_url) { 'https://example.com/app' }
+    let(:location_opts) { { 'url' => location_url, 'object_types' => object_types } }
+    let(:object_types) { %w[car truck] }
+
+    before do
+      @manifest_hash = {
+        'location' => {
+          'support' => {
+            location_name => location_opts
+          }
+        }
+      }
+    end
+
+    context 'when object_types is used with cov2_records_sidebar' do
+      it 'should not have an error with valid object_types' do
+        expect(create_package(@manifest_hash)).not_to have_error
+      end
+
+      it 'should have an error when object_types is empty' do
+        @manifest_hash['location']['support'][location_name]['object_types'] = []
+        expect(create_package(@manifest_hash)).to have_error(:object_types_empty)
+      end
+
+      it 'should have an error when object_types is not an array' do
+        @manifest_hash['location']['support'][location_name]['object_types'] = 'car'
+        expect(create_package(@manifest_hash)).to have_error(:object_types_must_be_array)
+      end
+
+      it 'should have an error when object_types contains non-string values' do
+        @manifest_hash['location']['support'][location_name]['object_types'] = ['car', 123, '']
+        expect(create_package(@manifest_hash)).to have_error(:object_types_invalid_entries)
+      end
+    end
+
+    context 'when object_types is used with a non-cov2_records_sidebar location' do
+      let(:location_name) { 'ticket_sidebar' }
+
+      it 'should silently ignore object_types' do
+        expect(create_package(@manifest_hash)).not_to have_error(:object_types_not_supported)
+      end
+    end
+  end
+
   context 'scope parameter validations' do
     context 'when a parameter has scopes but is not secure' do
       it 'should have an error requiring secure parameter for scopes' do

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -810,7 +810,7 @@ describe ZendeskAppsSupport::Validations::Manifest do
   context 'object_types validations' do
     let(:location_name) { ZendeskAppsSupport::Manifest::LocationOptions::OBJECT_TYPES_LOCATION }
     let(:location_url) { 'https://example.com/app' }
-    let(:location_opts) { { 'url' => location_url, 'object_types' => object_types } }
+    let(:location_opts) { { 'url' => location_url, 'objectTypes' => object_types } }
     let(:object_types) { %w[car truck] }
 
     before do
@@ -829,17 +829,17 @@ describe ZendeskAppsSupport::Validations::Manifest do
       end
 
       it 'should have an error when object_types is empty' do
-        @manifest_hash['location']['support'][location_name]['object_types'] = []
+        @manifest_hash['location']['support'][location_name]['objectTypes'] = []
         expect(create_package(@manifest_hash)).to have_error(:object_types_empty)
       end
 
       it 'should have an error when object_types is not an array' do
-        @manifest_hash['location']['support'][location_name]['object_types'] = 'car'
+        @manifest_hash['location']['support'][location_name]['objectTypes'] = 'car'
         expect(create_package(@manifest_hash)).to have_error(:object_types_must_be_array)
       end
 
       it 'should have an error when object_types contains non-string values' do
-        @manifest_hash['location']['support'][location_name]['object_types'] = ['car', 123, '']
+        @manifest_hash['location']['support'][location_name]['objectTypes'] = ['car', 123, '']
         expect(create_package(@manifest_hash)).to have_error(:object_types_invalid_entries)
       end
     end

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -863,7 +863,7 @@ describe ZendeskAppsSupport::Validations::Manifest do
         end
       end
 
-      context 'with supported location' do
+      context 'with non-custom_object_record_sidebar location' do
         let(:location_name) { 'ticket_sidebar' }
 
         it 'has an error that object_types is not supported' do
@@ -940,7 +940,7 @@ describe ZendeskAppsSupport::Validations::Manifest do
         end
       end
 
-      context 'with supported location' do
+      context 'with  non-custom_object_record_sidebar location' do
         let(:location_name) { 'ticket_sidebar' }
 
         it 'skips object_types validation' do

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -824,23 +824,51 @@ describe ZendeskAppsSupport::Validations::Manifest do
     end
 
     context 'when object_types is used with cov2_records_sidebar' do
-      it 'should not have an error with valid object_types' do
-        expect(create_package(@manifest_hash)).not_to have_error
+      context 'when is_cov2_sidebar_app_enabled is true' do
+        def validate_with_cov2_enabled(package)
+          ZendeskAppsSupport::Validations::Manifest.call(package, is_cov2_sidebar_app_enabled: true)
+        end
+
+        it 'should not have an error with valid object_types' do
+          create_package(@manifest_hash)
+          errors = validate_with_cov2_enabled(@package)
+          expect(errors).to be_empty
+        end
+
+        it 'should have an error when object_types is empty' do
+          @manifest_hash['location']['support'][location_name]['objectTypes'] = []
+          create_package(@manifest_hash)
+          errors = validate_with_cov2_enabled(@package)
+          expect(errors.find { |e| e.key == :object_types_empty }).not_to be_nil
+        end
+
+        it 'should have an error when object_types is not an array' do
+          @manifest_hash['location']['support'][location_name]['objectTypes'] = 'car'
+          create_package(@manifest_hash)
+          errors = validate_with_cov2_enabled(@package)
+          expect(errors.find { |e| e.key == :object_types_must_be_array }).not_to be_nil
+        end
+
+        it 'should have an error when object_types contains non-string values' do
+          @manifest_hash['location']['support'][location_name]['objectTypes'] = ['car', 123, '']
+          create_package(@manifest_hash)
+          errors = validate_with_cov2_enabled(@package)
+          expect(errors.find { |e| e.key == :object_types_invalid_entries }).not_to be_nil
+        end
       end
 
-      it 'should have an error when object_types is empty' do
-        @manifest_hash['location']['support'][location_name]['objectTypes'] = []
-        expect(create_package(@manifest_hash)).to have_error(:object_types_empty)
-      end
+      context 'when is_cov2_sidebar_app_enabled is false' do
+        it 'should have an error for cov2_records_sidebar location' do
+          create_package(@manifest_hash)
+          errors = ZendeskAppsSupport::Validations::Manifest.call(@package, is_cov2_sidebar_app_enabled: false)
+          expect(errors.find { |e| e.key == :invalid_location }).not_to be_nil
+        end
 
-      it 'should have an error when object_types is not an array' do
-        @manifest_hash['location']['support'][location_name]['objectTypes'] = 'car'
-        expect(create_package(@manifest_hash)).to have_error(:object_types_must_be_array)
-      end
-
-      it 'should have an error when object_types contains non-string values' do
-        @manifest_hash['location']['support'][location_name]['objectTypes'] = ['car', 123, '']
-        expect(create_package(@manifest_hash)).to have_error(:object_types_invalid_entries)
+        it 'should have an error for object_types not supported' do
+          create_package(@manifest_hash)
+          errors = ZendeskAppsSupport::Validations::Manifest.call(@package, is_cov2_sidebar_app_enabled: false)
+          expect(errors.find { |e| e.key == :object_types_not_supported }).not_to be_nil
+        end
       end
     end
 

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -808,7 +808,7 @@ describe ZendeskAppsSupport::Validations::Manifest do
   end
 
   context 'object_types validations' do
-    let(:location_name) { ZendeskAppsSupport::Manifest::LocationOptions::OBJECT_TYPES_LOCATION }
+    let(:location_name) { ZendeskAppsSupport::Location::OBJECT_TYPES_LOCATION }
     let(:location_url) { 'https://example.com/app' }
     let(:location_opts) { { 'url' => location_url, 'objectTypes' => object_types } }
     let(:object_types) { %w[car truck] }
@@ -875,8 +875,16 @@ describe ZendeskAppsSupport::Validations::Manifest do
     context 'when object_types is used with a non-cov2_records_sidebar location' do
       let(:location_name) { 'ticket_sidebar' }
 
-      it 'should silently ignore object_types' do
-        expect(create_package(@manifest_hash)).not_to have_error
+      it 'should have an error that object_types is not supported' do
+        create_package(@manifest_hash)
+        errors = ZendeskAppsSupport::Validations::Manifest.call(@package)
+        expect(errors.find { |e| e.key == :object_types_not_supported }).not_to be_nil
+      end
+
+      it 'should have an error even when is_cov2_sidebar_app_enabled is true' do
+        create_package(@manifest_hash)
+        errors = ZendeskAppsSupport::Validations::Manifest.call(@package, is_cov2_sidebar_app_enabled: true)
+        expect(errors.find { |e| e.key == :object_types_not_supported }).not_to be_nil
       end
     end
 
@@ -925,7 +933,7 @@ describe ZendeskAppsSupport::Validations::Manifest do
 
     context 'full opts passthrough with cov2 enabled' do
       it 'should have no errors when cov2 is enabled with valid object_types and all required fields' do
-        @manifest_hash = default_required_params(
+        create_package(
           'location' => {
             'support' => {
               location_name => {

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -808,10 +808,12 @@ describe ZendeskAppsSupport::Validations::Manifest do
   end
 
   context 'object_types validations' do
-    let(:location_name) { ZendeskAppsSupport::Location::OBJECT_TYPES_LOCATION }
+    let(:location_name) { ZendeskAppsSupport::Location::CUSTOM_OBJECT_RECORD_SIDEBAR_LOCATION }
     let(:location_url) { 'https://example.com/app' }
     let(:location_opts) { { 'url' => location_url, 'objectTypes' => object_types } }
     let(:object_types) { %w[car truck] }
+    let(:enabled_opts) { { validate_custom_object_record_sidebar_location: true } }
+    let(:disabled_opts) { { validate_custom_object_record_sidebar_location: false } }
 
     before do
       @manifest_hash = {
@@ -823,128 +825,188 @@ describe ZendeskAppsSupport::Validations::Manifest do
       }
     end
 
-    context 'when object_types is used with cov2_records_sidebar' do
-      context 'when is_cov2_sidebar_app_enabled is true' do
-        def validate_with_cov2_enabled(package)
-          ZendeskAppsSupport::Validations::Manifest.call(package, is_cov2_sidebar_app_enabled: true)
-        end
+    context 'when flag is enabled' do
+      def validate(package)
+        ZendeskAppsSupport::Validations::Manifest.call(package, enabled_opts)
+      end
 
-        it 'should not have an error with valid object_types' do
+      context 'with custom_object_record_sidebar location' do
+        it 'has no error with valid object_types' do
           create_package(@manifest_hash)
-          errors = validate_with_cov2_enabled(@package)
+          errors = validate(@package)
           expect(errors).to be_empty
         end
 
-        it 'should have an error when object_types is empty' do
+        it 'has an error when object_types is empty' do
           @manifest_hash['location']['support'][location_name]['objectTypes'] = []
           create_package(@manifest_hash)
-          errors = validate_with_cov2_enabled(@package)
+          errors = validate(@package)
           expect(errors.find { |e| e.key == :object_types_empty }).not_to be_nil
         end
 
-        it 'should have an error when object_types is not an array' do
+        it 'has an error when object_types is not an array' do
           @manifest_hash['location']['support'][location_name]['objectTypes'] = 'car'
           create_package(@manifest_hash)
-          errors = validate_with_cov2_enabled(@package)
+          errors = validate(@package)
           expect(errors.find { |e| e.key == :object_types_must_be_array }).not_to be_nil
         end
 
-        it 'should have an error when object_types contains non-string values' do
+        it 'has an error when object_types contains non-string values' do
           @manifest_hash['location']['support'][location_name]['objectTypes'] = ['car', 123, '']
           create_package(@manifest_hash)
-          errors = validate_with_cov2_enabled(@package)
+          errors = validate(@package)
           expect(errors.find { |e| e.key == :object_types_invalid_entries }).not_to be_nil
+        end
+
+        it 'has an error when objectTypes is missing' do
+          @manifest_hash['location']['support'][location_name] = { 'url' => location_url }
+          create_package(@manifest_hash)
+          errors = validate(@package)
+          expect(errors.find { |e| e.key == :object_types_required }).not_to be_nil
         end
       end
 
-      context 'when is_cov2_sidebar_app_enabled is false' do
-        it 'should have an error for cov2_records_sidebar location' do
+      context 'with supported location' do
+        let(:location_name) { 'ticket_sidebar' }
+
+        it 'has an error that object_types is not supported' do
           create_package(@manifest_hash)
-          errors = ZendeskAppsSupport::Validations::Manifest.call(@package, is_cov2_sidebar_app_enabled: false)
+          errors = validate(@package)
+          expect(errors.find { |e| e.key == :object_types_not_supported }).not_to be_nil
+        end
+
+        it 'has no error when objectTypes is not specified' do
+          @manifest_hash['location']['support'][location_name] = { 'url' => location_url }
+          create_package(@manifest_hash)
+          errors = validate(@package)
+          expect(errors.find { |e| e.key.to_s.include?('object_types') }).to be_nil
+        end
+      end
+
+      context 'with multiple locations' do
+        it 'validates all locations correctly' do
+          @manifest_hash['location']['support']['ticket_sidebar'] = { 'url' => 'https://example.com/ticket' }
+          create_package(@manifest_hash)
+          errors = validate(@package)
+          expect(errors).to be_empty
+        end
+      end
+
+      context 'object_types entry edge cases' do
+        it 'has an error when object_types contains whitespace-only strings' do
+          @manifest_hash['location']['support'][location_name]['objectTypes'] = ['car', '   ']
+          create_package(@manifest_hash)
+          errors = validate(@package)
+          expect(errors.find { |e| e.key == :object_types_invalid_entries }).not_to be_nil
+        end
+
+        it 'has an error when object_types contains nil values' do
+          @manifest_hash['location']['support'][location_name]['objectTypes'] = ['car', nil]
+          create_package(@manifest_hash)
+          errors = validate(@package)
+          expect(errors.find { |e| e.key == :object_types_invalid_entries }).not_to be_nil
+        end
+
+        it 'has an error when object_types contains numeric values' do
+          @manifest_hash['location']['support'][location_name]['objectTypes'] = [42]
+          create_package(@manifest_hash)
+          errors = validate(@package)
+          expect(errors.find { |e| e.key == :object_types_invalid_entries }).not_to be_nil
+        end
+
+        it 'has no error with a single valid object_type' do
+          @manifest_hash['location']['support'][location_name]['objectTypes'] = ['car']
+          create_package(@manifest_hash)
+          errors = validate(@package)
+          expect(errors).to be_empty
+        end
+      end
+    end
+
+    context 'when flag is disabled' do
+      def validate(package)
+        ZendeskAppsSupport::Validations::Manifest.call(package, disabled_opts)
+      end
+
+      context 'with custom_object_record_sidebar location' do
+        it 'reports custom_object_record_sidebar as invalid location' do
+          create_package(@manifest_hash)
+          errors = validate(@package)
           expect(errors.find { |e| e.key == :invalid_location }).not_to be_nil
         end
 
-        it 'should have an error for object_types not supported' do
+        it 'does not validate objectTypes when missing' do
+          @manifest_hash['location']['support'][location_name] = { 'url' => location_url }
           create_package(@manifest_hash)
-          errors = ZendeskAppsSupport::Validations::Manifest.call(@package, is_cov2_sidebar_app_enabled: false)
-          expect(errors.find { |e| e.key == :object_types_not_supported }).not_to be_nil
+          errors = validate(@package)
+          expect(errors.find { |e| e.key == :object_types_required }).to be_nil
+        end
+      end
+
+      context 'with supported location' do
+        let(:location_name) { 'ticket_sidebar' }
+
+        it 'skips object_types validation' do
+          create_package(@manifest_hash)
+          errors = validate(@package)
+          expect(errors.find { |e| e.key == :object_types_not_supported }).to be_nil
+        end
+      end
+
+      context 'with multiple locations' do
+        it 'reports custom_object_record_sidebar as invalid' do
+          @manifest_hash['location']['support']['ticket_sidebar'] = { 'url' => 'https://example.com/ticket' }
+          create_package(@manifest_hash)
+          errors = validate(@package)
+          invalid_loc_error = errors.find { |e| e.key == :invalid_location }
+          expect(invalid_loc_error).not_to be_nil
+          expect(invalid_loc_error.data[:invalid_locations]).to include('custom_object_record_sidebar')
+        end
+      end
+
+      context 'with supported locations only' do
+        it 'has no errors' do
+          @manifest_hash = {
+            'location' => {
+              'support' => {
+                'ticket_sidebar' => { 'url' => 'https://example.com/app' }
+              }
+            }
+          }
+          create_package(@manifest_hash)
+          errors = validate(@package)
+          expect(errors).to be_empty
         end
       end
     end
 
-    context 'when object_types is used with a non-cov2_records_sidebar location' do
-      let(:location_name) { 'ticket_sidebar' }
-
-      it 'should have an error that object_types is not supported' do
-        create_package(@manifest_hash)
-        errors = ZendeskAppsSupport::Validations::Manifest.call(@package)
-        expect(errors.find { |e| e.key == :object_types_not_supported }).not_to be_nil
+    context 'when no flag is passed' do
+      def validate(package)
+        ZendeskAppsSupport::Validations::Manifest.call(package)
       end
 
-      it 'should have an error even when is_cov2_sidebar_app_enabled is true' do
-        create_package(@manifest_hash)
-        errors = ZendeskAppsSupport::Validations::Manifest.call(@package, is_cov2_sidebar_app_enabled: true)
-        expect(errors.find { |e| e.key == :object_types_not_supported }).not_to be_nil
-      end
-    end
-
-    context 'edge cases for object_types entries' do
-      def validate_with_cov2_enabled(package)
-        ZendeskAppsSupport::Validations::Manifest.call(package, is_cov2_sidebar_app_enabled: true)
+      context 'with custom_object_record_sidebar location' do
+        it 'treats custom_object_record_sidebar as invalid location' do
+          create_package(@manifest_hash)
+          errors = validate(@package)
+          invalid_loc_error = errors.find { |e| e.key == :invalid_location }
+          expect(invalid_loc_error).not_to be_nil
+        end
       end
 
-      it 'should have an error when object_types contains whitespace-only strings' do
-        @manifest_hash['location']['support'][location_name]['objectTypes'] = ['car', '   ']
-        create_package(@manifest_hash)
-        errors = validate_with_cov2_enabled(@package)
-        expect(errors.find { |e| e.key == :object_types_invalid_entries }).not_to be_nil
-      end
-
-      it 'should have an error when object_types contains nil values' do
-        @manifest_hash['location']['support'][location_name]['objectTypes'] = ['car', nil]
-        create_package(@manifest_hash)
-        errors = validate_with_cov2_enabled(@package)
-        expect(errors.find { |e| e.key == :object_types_invalid_entries }).not_to be_nil
-      end
-
-      it 'should have an error when object_types contains numeric values' do
-        @manifest_hash['location']['support'][location_name]['objectTypes'] = [42]
-        create_package(@manifest_hash)
-        errors = validate_with_cov2_enabled(@package)
-        expect(errors.find { |e| e.key == :object_types_invalid_entries }).not_to be_nil
-      end
-
-      it 'should not have an error with a single valid object_type' do
-        @manifest_hash['location']['support'][location_name]['objectTypes'] = ['car']
-        create_package(@manifest_hash)
-        errors = validate_with_cov2_enabled(@package)
-        expect(errors).to be_empty
-      end
-    end
-
-    context 'cov2_records_sidebar reported as invalid_location when flag is false' do
-      it 'should include cov2_records_sidebar in invalid locations' do
-        create_package(@manifest_hash)
-        errors = ZendeskAppsSupport::Validations::Manifest.call(@package, is_cov2_sidebar_app_enabled: false)
-        invalid_loc_error = errors.find { |e| e.key == :invalid_location }
-        expect(invalid_loc_error).not_to be_nil
-      end
-    end
-
-    context 'full opts passthrough with cov2 enabled' do
-      it 'should have no errors when cov2 is enabled with valid object_types and all required fields' do
-        create_package(
-          'location' => {
-            'support' => {
-              location_name => {
-                'url' => 'https://example.com/app',
-                'objectTypes' => %w[car truck]
+      context 'with supported location without objectTypes' do
+        it 'has no object_types errors' do
+          @manifest_hash = {
+            'location' => {
+              'support' => {
+                'ticket_sidebar' => { 'url' => 'https://example.com/app' }
               }
             }
           }
-        )
-        errors = ZendeskAppsSupport::Validations::Manifest.call(@package, is_cov2_sidebar_app_enabled: true)
-        expect(errors).to be_empty
+          create_package(@manifest_hash)
+          errors = validate(@package)
+          expect(errors.find { |e| e.key.to_s.include?('object_types') }).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION

💐

/cc @zendesk/wattle

### Description

- Add new `custom_object_record_sidebar` location (id: 27) for the Support product, enabling apps to render in a custom objects v2 records sidebar. The location is orderable, collapsible, and visible.
- Introduce `objectTypes` location option scoped exclusively to `custom_object_record_sidebar`, allowing apps to declare which custom object types the sidebar should render for. `objectTypes` is **required** for `custom_object_record_sidebar` — omitting it raises `:object_types_required`.
- Add manifest validations for `objectTypes`: must be a non-empty array of non-empty strings; rejected on any location other than `custom_object_record_sidebar` when the flag is enabled. Edge cases covered include whitespace-only strings, nil values, and numeric entries.
- Gate the `custom_object_record_sidebar` location behind a `validate_custom_object_record_sidebar_location` option passed through `Package#validate` → `Validations::Manifest.call`. When the flag is off (default), the location is reported as invalid. **Known gap:** when the flag is off, `objectTypes` on supported locations (e.g., `ticket_sidebar`) is silently ignored rather than rejected — a follow-up is needed to raise `:object_types_not_supported` regardless of the flag state.
- Add locale strings and translator-friendly translations for **five** new `objectTypes` validation errors:
  1. `object_types_must_be_array` — value is not an array
  2. `object_types_empty` — array is present but empty
  3. `object_types_invalid_entries` — array contains non-string, empty, or whitespace-only entries
  4. `object_types_not_supported` — `objectTypes` specified on a location that does not support it
  5. `object_types_required` — `objectTypes` omitted on `custom_object_record_sidebar`
- Add comprehensive specs covering location options parsing, manifest parsing, and all validation rules including edge cases, multi-location manifests, and default flag behaviour.

### References

- [CRYSTAL-1381](https://zendesk.atlassian.net/browse/CRYSTAL-1381)

### Screenshots & GIFs

- N/A

#### Before merging this PR
- [ ] Fill out the Risks section
- [ ] Think about performance and security issues

### Risks

- Medium: `objectTypes` is **required** for `custom_object_record_sidebar`, making this a stricter contract than "validated only when present." There are five validation error paths (not four as originally noted — includes `object_types_required`). When the flag is disabled (default), `objectTypes` on supported locations (e.g., `ticket_sidebar`) is silently ignored rather than rejected — apps could ship manifests containing `objectTypes` on non-target locations without error until the flag is turned on, at which point those manifests would start failing validation. Existing locations and manifest parsing are unaffected. When the flag is off, `custom_object_record_sidebar` is treated as an invalid location, so no apps can use it until explicitly enabled.

[CRYSTAL-1381]: https://zendesk.atlassian.net/browse/CRYSTAL-1381