### PR TITLE
Release v4.51.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zendesk_apps_support (4.50.0)
+    zendesk_apps_support (4.51.0)
       erubis
       i18n (>= 1.7.1)
       image_size (~> 2.0.2)

--- a/lib/zendesk_apps_support/version.rb
+++ b/lib/zendesk_apps_support/version.rb
@@ -1,3 +1,3 @@
 module ZendeskAppsSupport
-  VERSION = '4.50.0'
+  VERSION = '4.51.0'
 end


### PR DESCRIPTION
### Description

- Bump `ZendeskAppsSupport::VERSION` from `4.50.0` to `4.51.0` for the gem release.
- Update `Gemfile.lock` so the local path gem version stays in sync with the release version.

### References

- https://github.com/zendesk/zendesk_apps_support/pull/428

### Screenshots & GIFs

- N/A

#### Before merging this PR

- [x] Fill out the Risks section
- [x] Think about performance and security issues

### Risks

- None: Release metadata/version-only update with no runtime behavior changes.