### PR TITLE
Validations for mtls parameter

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -316,8 +316,8 @@ en:
             object_types_required: objectTypes is required for the %{location} location.
             mtls_parameter_cannot_have_certain_settings: mtls parameter cannot have
               default, secure, or scopes settings.
-            mtls_parameter_cannot_exceed_three_parameters: You can only have up to
-              three mtls parameters.
+            too_many_mtls_parameters: 'Too many parameters with type ''mtls'': three
+              permitted'
         warning:
           app_build:
             deprecated_version: You are targeting a deprecated version of the framework.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -318,6 +318,12 @@ en:
               default, secure, or scopes settings.
             too_many_mtls_parameters: 'Too many parameters with type ''mtls'': three
               permitted'
+            mtls_allowed_domain_contains_scheme: "%{field} must not include a protocol
+              or scheme."
+            mtls_allowed_domain_too_long: "%{field} must not exceed 253 characters."
+            mtls_allowed_domain_invalid_wildcard: "%{field} can only use a wildcard
+              as the first two characters, e.g. *.example.com."
+            mtls_allowed_domain_invalid_format: "%{field} must be a valid domain name."
         warning:
           app_build:
             deprecated_version: You are targeting a deprecated version of the framework.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -314,6 +314,10 @@ en:
             object_types_not_supported: objectTypes is not supported for the %{location}
               location.
             object_types_required: objectTypes is required for the %{location} location.
+            mtls_parameter_cannot_have_certain_settings: mtls parameter cannot have
+              default, secure, or scopes settings.
+            mtls_parameter_cannot_exceed_three_parameters: You can only have up to
+              three mtls parameters.
         warning:
           app_build:
             deprecated_version: You are targeting a deprecated version of the framework.

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -712,4 +712,3 @@ parts:
       key: "txt.apps.admin.error.app_build.too_many_mtls_parameters"
       title: "Validation message to indicate that mtls parameter cannot exceed three parameters. Do not translate 'mtls' as it is a manifest property."
       value: "Too many parameters with type 'mtls': three permitted"
-    

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -700,3 +700,16 @@ parts:
         Do not translate 'scopes'. %{params} refers to secure parameters with no scopes configured.
         Scopes in manifest refers to https://developer.zendesk.com/documentation/apps/getting-started/setting-up-new-apps/#scopes"
       value: "The scopes property is not configured for parameter(s): %{params}. This may cause token exposure vulnerabilities. Learn about: %{link}"
+  - translation:
+      key: "txt.apps.admin.error.app_build.mtls_parameter_cannot_have_certain_settings"
+      title: "Validation message to indicate that mtls parameter cannot have default, secure, or scopes settings.
+        Do not translate 'mtls', 'secure', 'default' and 'scopes' as they are manifest properties.
+        'secure' in manifest refers to https://developer.zendesk.com/documentation/apps/getting-started/setting-up-new-apps/#secure
+        'scopes' in manifest refers to https://developer.zendesk.com/documentation/apps/getting-started/setting-up-new-apps/#scopes
+        'default' in manifest refers to https://developer.zendesk.com/documentation/apps/getting-started/setting-up-new-apps/#default"
+      value: "mtls parameter cannot have default, secure, or scopes settings."
+  - translation:
+      key: "txt.apps.admin.error.app_build.mtls_parameter_cannot_exceed_three_parameters"
+      title: "Validation message to indicate that mtls parameter cannot exceed three parameters. Do not translate 'mtls' as it is a manifest property."
+      value: "You can only have up to three mtls parameters."
+    

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -709,7 +709,7 @@ parts:
         'default' in manifest refers to https://developer.zendesk.com/documentation/apps/getting-started/setting-up-new-apps/#default"
       value: "mtls parameter cannot have default, secure, or scopes settings."
   - translation:
-      key: "txt.apps.admin.error.app_build.mtls_parameter_cannot_exceed_three_parameters"
+      key: "txt.apps.admin.error.app_build.too_many_mtls_parameters"
       title: "Validation message to indicate that mtls parameter cannot exceed three parameters. Do not translate 'mtls' as it is a manifest property."
-      value: "You can only have up to three mtls parameters."
+      value: "Too many parameters with type 'mtls': three permitted"
     

--- a/config/locales/translations/zendesk_apps_support.yml
+++ b/config/locales/translations/zendesk_apps_support.yml
@@ -712,3 +712,23 @@ parts:
       key: "txt.apps.admin.error.app_build.too_many_mtls_parameters"
       title: "Validation message to indicate that mtls parameter cannot exceed three parameters. Do not translate 'mtls' as it is a manifest property."
       value: "Too many parameters with type 'mtls': three permitted"
+  - translation:
+      key: "txt.apps.admin.error.app_build.mtls_allowed_domain_contains_scheme"
+      title: "Validation message to indicate that the allowed_domain property of an mtls parameter must not include a protocol or scheme.
+        %{field} refers to the manifest field path."
+      value: "%{field} must not include a protocol or scheme."
+  - translation:
+      key: "txt.apps.admin.error.app_build.mtls_allowed_domain_too_long"
+      title: "Validation message to indicate that the allowed_domain property of an mtls parameter exceeds the maximum length of 253 characters.
+        %{field} refers to the manifest field path."
+      value: "%{field} must not exceed 253 characters."
+  - translation:
+      key: "txt.apps.admin.error.app_build.mtls_allowed_domain_invalid_wildcard"
+      title: "Validation message to indicate that the allowed_domain property of an mtls parameter uses a wildcard incorrectly.
+        %{field} refers to the manifest field path."
+      value: "%{field} can only use a wildcard as the first two characters, e.g. *.example.com."
+  - translation:
+      key: "txt.apps.admin.error.app_build.mtls_allowed_domain_invalid_format"
+      title: "Validation message to indicate that the allowed_domain property of an mtls parameter is not a valid domain name.
+        %{field} refers to the manifest field path."
+      value: "%{field} must be a valid domain name."

--- a/lib/zendesk_apps_support/manifest/parameter.rb
+++ b/lib/zendesk_apps_support/manifest/parameter.rb
@@ -3,7 +3,7 @@
 module ZendeskAppsSupport
   class Manifest
     class Parameter
-      TYPES = %w[text checkbox url number multiline hidden oauth].freeze
+      TYPES = %w[text checkbox url number multiline hidden oauth mtls].freeze
       ATTRIBUTES = %i[name type required secure default scopes].freeze
       attr_reader(*ATTRIBUTES)
       def default?

--- a/lib/zendesk_apps_support/manifest/parameter.rb
+++ b/lib/zendesk_apps_support/manifest/parameter.rb
@@ -4,7 +4,7 @@ module ZendeskAppsSupport
   class Manifest
     class Parameter
       TYPES = %w[text checkbox url number multiline hidden oauth mtls].freeze
-      ATTRIBUTES = %i[name type required secure default scopes].freeze
+      ATTRIBUTES = %i[name type required secure default scopes allowed_domain].freeze
       attr_reader(*ATTRIBUTES)
       def default?
         @has_default
@@ -18,6 +18,7 @@ module ZendeskAppsSupport
         @has_default = p.key? 'default'
         @default = p['default'] if @has_default
         @scopes = p['scopes']
+        @allowed_domain = p['allowed_domain']
       end
     end
   end

--- a/lib/zendesk_apps_support/package.rb
+++ b/lib/zendesk_apps_support/package.rb
@@ -35,9 +35,14 @@ module ZendeskAppsSupport
       marketplace = options.fetch(:marketplace, true)
       skip_marketplace_translations = options.fetch(:skip_marketplace_translations, false)
       validate_custom_object_record_sidebar_location = options.fetch(:validate_custom_object_record_sidebar_location, false)
+      validate_mtls_param = options.fetch(:validate_mtls_param, false)
 
       errors = []
-      errors << Validations::Manifest.call(self, validate_custom_object_record_sidebar_location: validate_custom_object_record_sidebar_location)
+      errors << Validations::Manifest.call(
+        self,
+        validate_custom_object_record_sidebar_location: validate_custom_object_record_sidebar_location,
+        validate_mtls_param: validate_mtls_param
+      )
 
       if has_valid_manifest?(errors)
         errors << Validations::Marketplace.call(self) if marketplace

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -123,8 +123,8 @@ module ZendeskAppsSupport
         end
 
         def too_many_mtls_parameters(manifest)
-          mtls_parameters = manifest.parameters.select { |parameter| parameter.type == 'mtls' }
-          ValidationError.new(:too_many_mtls_parameters) if mtls_parameters.count > 3
+          mtls_parameter_count = manifest.parameters.count { |parameter| parameter.type == 'mtls' }
+          ValidationError.new(:too_many_mtls_parameters) if mtls_parameter_count > 3
         end
 
         def invalid_secure_param_scopes_errors(manifest)

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -97,7 +97,7 @@ module ZendeskAppsSupport
               name_as_parameter_name_error(manifest),
               invalid_secure_param_scopes_errors(manifest),
               (mtls_cannot_have_certain_settings(manifest) if validate_mtls_param),
-              (mtls_cannot_exceed_three_parameters(manifest) if validate_mtls_param)
+              (too_many_mtls_parameters(manifest) if validate_mtls_param)
             ]
           end
         end
@@ -113,7 +113,7 @@ module ZendeskAppsSupport
         def mtls_cannot_have_certain_settings(manifest)
           manifest.parameters.map do |parameter|
             if parameter.type == 'mtls' && invalid_mtls_settings?(parameter)
-              return ValidationError.new('mtls_parameter_cannot_have_certain_settings')
+              return ValidationError.new(:mtls_parameter_cannot_have_certain_settings)
             end
           end
         end
@@ -122,9 +122,9 @@ module ZendeskAppsSupport
           parameter.secure || parameter.default? || !parameter.scopes.nil?
         end
 
-        def mtls_cannot_exceed_three_parameters(manifest)
+        def too_many_mtls_parameters(manifest)
           mtls_parameters = manifest.parameters.select { |parameter| parameter.type == 'mtls' }
-          ValidationError.new('mtls_parameter_cannot_exceed_three_parameters') if mtls_parameters.count > 3
+          ValidationError.new(:too_many_mtls_parameters) if mtls_parameters.count > 3
         end
 
         def invalid_secure_param_scopes_errors(manifest)

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -12,6 +12,10 @@ module ZendeskAppsSupport
       PARAMETER_TYPES = ZendeskAppsSupport::Manifest::Parameter::TYPES
       OAUTH_MANIFEST_LINK = 'https://developer.zendesk.com/apps/docs/developer-guide/manifest#oauth'
       SECURE_PARAM_SCOPES = %w[header body url jwt_secret_key jwt_claim basic_auth_username basic_auth_password].freeze
+      MTLS = 'mtls'
+      MTLS_ALLOWED_DOMAIN_MAX_LENGTH = 253
+      MTLS_ALLOWED_DOMAIN_LABEL_MAX_LENGTH = 63
+      MTLS_ALLOWED_DOMAIN_LABEL_REGEXP = /\A[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\z/
 
       class << self
         def call(package, validate_custom_object_record_sidebar_location: false, validate_mtls_param: false)
@@ -97,7 +101,8 @@ module ZendeskAppsSupport
               name_as_parameter_name_error(manifest),
               invalid_secure_param_scopes_errors(manifest),
               (mtls_cannot_have_certain_settings(manifest) if validate_mtls_param),
-              (too_many_mtls_parameters(manifest) if validate_mtls_param)
+              (too_many_mtls_parameters(manifest) if validate_mtls_param),
+              (mtls_allowed_domain_errors(manifest) if validate_mtls_param)
             ]
           end
         end
@@ -108,23 +113,6 @@ module ZendeskAppsSupport
               return ValidationError.new('oauth_parameter_cannot_be_secure')
             end
           end
-        end
-
-        def mtls_cannot_have_certain_settings(manifest)
-          manifest.parameters.map do |parameter|
-            if parameter.type == 'mtls' && invalid_mtls_settings?(parameter)
-              return ValidationError.new(:mtls_parameter_cannot_have_certain_settings)
-            end
-          end
-        end
-
-        def invalid_mtls_settings?(parameter)
-          parameter.secure || parameter.default? || !parameter.scopes.nil?
-        end
-
-        def too_many_mtls_parameters(manifest)
-          mtls_parameter_count = manifest.parameters.count { |parameter| parameter.type == 'mtls' }
-          ValidationError.new(:too_many_mtls_parameters) if mtls_parameter_count > 3
         end
 
         def invalid_secure_param_scopes_errors(manifest)
@@ -497,7 +485,7 @@ module ZendeskAppsSupport
         end
 
         def invalid_type_error(manifest, validate_mtls_param: false)
-          allowed_types = validate_mtls_param ? PARAMETER_TYPES : PARAMETER_TYPES - ['mtls']
+          allowed_types = validate_mtls_param ? PARAMETER_TYPES : PARAMETER_TYPES - [MTLS]
 
           invalid_types = []
           manifest.parameters.each do |parameter|
@@ -553,6 +541,82 @@ module ZendeskAppsSupport
           uri.is_a?(URI::HTTP) && !host_empty
         rescue URI::InvalidURIError
           false
+        end
+
+        def mtls_cannot_have_certain_settings(manifest)
+          manifest.parameters.map do |parameter|
+            if parameter.type == MTLS && invalid_mtls_settings?(parameter)
+              return ValidationError.new(:mtls_parameter_cannot_have_certain_settings)
+            end
+          end
+        end
+
+        def invalid_mtls_settings?(parameter)
+          parameter.secure || parameter.default? || !parameter.scopes.nil?
+        end
+
+        def too_many_mtls_parameters(manifest)
+          mtls_parameter_count = manifest.parameters.count { |parameter| parameter.type == MTLS }
+          ValidationError.new(:too_many_mtls_parameters) if mtls_parameter_count > 3
+        end
+
+        def mtls_allowed_domain_errors(manifest)
+          manifest.parameters.each_with_object([]) do |parameter, errors|
+            next unless parameter.type == MTLS
+
+            errors.concat(mtls_allowed_domain_error_for(parameter))
+          end
+        end
+
+        def mtls_allowed_domain_error_for(parameter)
+          field = "parameters[name=\"#{parameter.name}\"].allowed_domain"
+          allowed_domain = parameter.allowed_domain
+
+          presence_or_type_error = mtls_allowed_domain_presence_or_type_error(allowed_domain, field)
+          return [presence_or_type_error] if presence_or_type_error
+
+          errors = mtls_allowed_domain_syntax_errors(allowed_domain, field)
+          return errors if errors.any?
+
+          errors << mtls_allowed_domain_format_error(allowed_domain, field)
+          errors.compact
+        end
+
+        def mtls_allowed_domain_presence_or_type_error(allowed_domain, field)
+          if allowed_domain.nil? || allowed_domain == ''
+            return ValidationError.new(:field_cannot_be_empty, field: field)
+          end
+
+          return if allowed_domain.is_a?(String)
+
+          ValidationError.new(:unacceptable_string, field: field, value: allowed_domain)
+        end
+
+        def mtls_allowed_domain_syntax_errors(allowed_domain, field)
+          errors = []
+          if allowed_domain.include?('://')
+            errors << ValidationError.new(:mtls_allowed_domain_contains_scheme, field: field)
+          end
+          if allowed_domain.length > MTLS_ALLOWED_DOMAIN_MAX_LENGTH
+            errors << ValidationError.new(:mtls_allowed_domain_too_long, field: field)
+          end
+          if allowed_domain.include?('*') && !allowed_domain.start_with?('*.')
+            errors << ValidationError.new(:mtls_allowed_domain_invalid_wildcard, field: field)
+          end
+          errors
+        end
+
+        def mtls_allowed_domain_format_error(allowed_domain, field)
+          hostname = allowed_domain.start_with?('*.') ? allowed_domain[2..] : allowed_domain
+          labels = hostname.split('.')
+
+          return if labels.size >= 2 && labels.all? { |label| valid_mtls_domain_label?(label) }
+
+          ValidationError.new(:mtls_allowed_domain_invalid_format, field: field)
+        end
+
+        def valid_mtls_domain_label?(label)
+          label.length <= MTLS_ALLOWED_DOMAIN_LABEL_MAX_LENGTH && label.match?(MTLS_ALLOWED_DOMAIN_LABEL_REGEXP)
         end
       end
     end

--- a/lib/zendesk_apps_support/validations/manifest.rb
+++ b/lib/zendesk_apps_support/validations/manifest.rb
@@ -14,7 +14,7 @@ module ZendeskAppsSupport
       SECURE_PARAM_SCOPES = %w[header body url jwt_secret_key jwt_claim basic_auth_username basic_auth_password].freeze
 
       class << self
-        def call(package, validate_custom_object_record_sidebar_location: false)
+        def call(package, validate_custom_object_record_sidebar_location: false, validate_mtls_param: false)
           unless package.has_file?('manifest.json')
             nested_manifest = package.files.find { |file| file =~ %r{\A[^/]+?/manifest\.json\Z} }
             if nested_manifest
@@ -23,7 +23,8 @@ module ZendeskAppsSupport
             return [ValidationError.new(:missing_manifest)]
           end
           collate_manifest_errors(package,
-                                  validate_custom_object_record_sidebar_location: validate_custom_object_record_sidebar_location)
+                                  validate_custom_object_record_sidebar_location: validate_custom_object_record_sidebar_location,
+                                  validate_mtls_param: validate_mtls_param)
         rescue JSON::ParserError => e
           return [ValidationError.new(:manifest_not_json, errors: e)]
         rescue ZendeskAppsSupport::Manifest::OverrideError => e
@@ -32,7 +33,8 @@ module ZendeskAppsSupport
 
         private
 
-        def collate_manifest_errors(package, validate_custom_object_record_sidebar_location: false)
+        def collate_manifest_errors(package, validate_custom_object_record_sidebar_location: false,
+                                    validate_mtls_param: false)
           manifest = package.manifest
 
           errors = [
@@ -41,7 +43,7 @@ module ZendeskAppsSupport
             oauth_error(manifest),
             default_locale_error(manifest, package),
             validate_urls(manifest),
-            validate_parameters(manifest),
+            validate_parameters(manifest, validate_mtls_param: validate_mtls_param),
             if manifest.requirements_only? || manifest.marketing_only?
               [ ban_location(manifest),
                 ban_framework_version(manifest) ]
@@ -82,18 +84,20 @@ module ZendeskAppsSupport
           errors
         end
 
-        def validate_parameters(manifest)
+        def validate_parameters(manifest, validate_mtls_param: false)
           if manifest.marketing_only?
             marketing_only_errors(manifest)
           else
             [
               parameters_error(manifest),
               invalid_hidden_parameter_error(manifest),
-              invalid_type_error(manifest),
+              invalid_type_error(manifest, validate_mtls_param: validate_mtls_param),
               too_many_oauth_parameters(manifest),
               oauth_cannot_be_secure(manifest),
               name_as_parameter_name_error(manifest),
-              invalid_secure_param_scopes_errors(manifest)
+              invalid_secure_param_scopes_errors(manifest),
+              (mtls_cannot_have_certain_settings(manifest) if validate_mtls_param),
+              (mtls_cannot_exceed_three_parameters(manifest) if validate_mtls_param)
             ]
           end
         end
@@ -104,6 +108,23 @@ module ZendeskAppsSupport
               return ValidationError.new('oauth_parameter_cannot_be_secure')
             end
           end
+        end
+
+        def mtls_cannot_have_certain_settings(manifest)
+          manifest.parameters.map do |parameter|
+            if parameter.type == 'mtls' && invalid_mtls_settings?(parameter)
+              return ValidationError.new('mtls_parameter_cannot_have_certain_settings')
+            end
+          end
+        end
+
+        def invalid_mtls_settings?(parameter)
+          parameter.secure || parameter.default? || !parameter.scopes.nil?
+        end
+
+        def mtls_cannot_exceed_three_parameters(manifest)
+          mtls_parameters = manifest.parameters.select { |parameter| parameter.type == 'mtls' }
+          ValidationError.new('mtls_parameter_cannot_exceed_three_parameters') if mtls_parameters.count > 3
         end
 
         def invalid_secure_param_scopes_errors(manifest)
@@ -475,12 +496,14 @@ module ZendeskAppsSupport
           end
         end
 
-        def invalid_type_error(manifest)
+        def invalid_type_error(manifest, validate_mtls_param: false)
+          allowed_types = validate_mtls_param ? PARAMETER_TYPES : PARAMETER_TYPES - ['mtls']
+
           invalid_types = []
           manifest.parameters.each do |parameter|
             parameter_type = parameter.type
 
-            invalid_types << parameter_type unless PARAMETER_TYPES.include?(parameter_type)
+            invalid_types << parameter_type unless allowed_types.include?(parameter_type)
           end
 
           if invalid_types.any?

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -131,6 +131,22 @@ describe ZendeskAppsSupport::Manifest do
       expect(parameter.required).to eq manifest_hash[:parameters][0][:required]
       expect(parameter.secure).to eq manifest_hash[:parameters][0][:secure]
     end
+
+    context 'with an mtls parameter' do
+      before do
+        manifest_hash[:parameters] = [
+          { name: 'mtls param', type: 'mtls' }
+        ]
+      end
+
+      it 'is not filtered out and is exposed as a Parameter object' do
+        expect(manifest.parameters.length).to eq(1)
+        parameter = manifest.parameters.first
+        expect(parameter).to be_a(ZendeskAppsSupport::Manifest::Parameter)
+        expect(parameter.name).to eq 'mtls param'
+        expect(parameter.type).to eq 'mtls'
+      end
+    end
   end
 
   describe '#location_options' do

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -756,14 +756,14 @@ describe ZendeskAppsSupport::Validations::Manifest do
           parameter_hash = { 'parameters' => mtls_parameters(3) }
           create_package(parameter_hash)
           errors = ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: true)
-          expect(errors.map(&:to_s)).not_to include('You can only have up to three mtls parameters.')
+          expect(errors.map(&:to_s)).not_to include("Too many parameters with type 'mtls': three permitted")
         end
 
         it 'has an error when there are more than three mtls parameters' do
           parameter_hash = { 'parameters' => mtls_parameters(4) }
           create_package(parameter_hash)
           errors = ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: true)
-          expect(errors.map(&:to_s)).to include('You can only have up to three mtls parameters.')
+          expect(errors.map(&:to_s)).to include("Too many parameters with type 'mtls': three permitted")
         end
       end
 
@@ -772,7 +772,7 @@ describe ZendeskAppsSupport::Validations::Manifest do
           parameter_hash = { 'parameters' => mtls_parameters(4) }
           create_package(parameter_hash)
           errors = ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: false)
-          expect(errors.map(&:to_s)).not_to include('You can only have up to three mtls parameters.')
+          expect(errors.map(&:to_s)).not_to include("Too many parameters with type 'mtls': three permitted")
         end
       end
     end

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -655,6 +655,128 @@ describe ZendeskAppsSupport::Validations::Manifest do
       expect(package).not_to have_error
     end
 
+    context 'mtls parameter type' do
+      let(:parameter_hash) do
+        {
+          'parameters' =>
+          [
+            {
+              'name' => 'mtls param',
+              'type' => 'mtls'
+            }
+          ]
+        }
+      end
+
+      context 'when validate_mtls_param is false or nil' do
+        it 'has an error when validate_mtls_param is false' do
+          create_package(parameter_hash)
+          errors = ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: false)
+          expect(errors.map(&:to_s)).to include('mtls is an invalid parameter type.')
+        end
+
+        it 'has an error by default when validate_mtls_param is nil' do
+          create_package(parameter_hash)
+          expect(@package).to have_error 'mtls is an invalid parameter type.'
+        end
+      end
+
+      context 'when validate_mtls_param is true' do
+        it 'has no error' do
+          create_package(parameter_hash)
+          errors = ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: true)
+          expect(errors.map(&:to_s)).not_to include('mtls is an invalid parameter type.')
+        end
+      end
+    end
+
+    context 'mtls_cannot_have_certain_settings' do
+      def errors_for(parameter_overrides)
+        parameter_hash = {
+          'parameters' =>
+          [
+            {
+              'name' => 'mtls param',
+              'type' => 'mtls'
+            }.merge(parameter_overrides)
+          ]
+        }
+        create_package(parameter_hash)
+        ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: true)
+      end
+
+      context 'when validate_mtls_param is true' do
+        it 'has no error when mtls parameter has none of default, secure or scopes set' do
+          errors = errors_for({})
+          expect(errors.map(&:to_s)).not_to include('mtls parameter cannot have default, secure, or scopes settings.')
+        end
+
+        it 'has an error when mtls parameter has secure set' do
+          errors = errors_for('secure' => true)
+          expect(errors.map(&:to_s)).to include('mtls parameter cannot have default, secure, or scopes settings.')
+        end
+
+        it 'has an error when mtls parameter has default set' do
+          errors = errors_for('default' => 'mysubdomain')
+          expect(errors.map(&:to_s)).to include('mtls parameter cannot have default, secure, or scopes settings.')
+        end
+
+        it 'has an error when mtls parameter has scopes set' do
+          errors = errors_for('scopes' => ['header'], 'secure' => true)
+          expect(errors.map(&:to_s)).to include('mtls parameter cannot have default, secure, or scopes settings.')
+        end
+      end
+
+      context 'when validate_mtls_param is false' do
+        it 'does not check mtls parameter settings' do
+          parameter_hash = {
+            'parameters' =>
+            [
+              {
+                'name' => 'mtls param',
+                'type' => 'mtls',
+                'secure' => true
+              }
+            ]
+          }
+          create_package(parameter_hash)
+          errors = ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: false)
+          expect(errors.map(&:to_s)).not_to include('mtls parameter cannot have default, secure, or scopes settings.')
+        end
+      end
+    end
+
+    context 'number of mtls parameters' do
+      def mtls_parameters(count)
+        Array.new(count) { |i| { 'name' => "mtls param #{i}", 'type' => 'mtls' } }
+      end
+
+      context 'when validate_mtls_param is true' do
+        it 'has no error when there are three or fewer mtls parameters' do
+          parameter_hash = { 'parameters' => mtls_parameters(3) }
+          create_package(parameter_hash)
+          errors = ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: true)
+          expect(errors.map(&:to_s)).not_to include('You can only have up to three mtls parameters.')
+        end
+
+        it 'has an error when there are more than three mtls parameters' do
+          parameter_hash = { 'parameters' => mtls_parameters(4) }
+          create_package(parameter_hash)
+          errors = ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: true)
+          expect(errors.map(&:to_s)).to include('You can only have up to three mtls parameters.')
+        end
+      end
+
+      context 'when validate_mtls_param is false' do
+        it 'does not check the count of mtls parameters' do
+          parameter_hash = { 'parameters' => mtls_parameters(4) }
+          create_package(parameter_hash)
+          errors = ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: false)
+          expect(errors.map(&:to_s)).not_to include('You can only have up to three mtls parameters.')
+        end
+      end
+    end
+
     it 'should have only one oauth type for parameter' do
       parameter_hash = {
         'parameters' =>

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -655,202 +655,158 @@ describe ZendeskAppsSupport::Validations::Manifest do
       expect(package).not_to have_error
     end
 
-    context 'mtls parameter type' do
-      let(:parameter_hash) do
-        {
-          'parameters' =>
-          [
+    context 'mtls parameter validations' do
+      context 'when validate_mtls_param is true' do
+        context 'mtls parameter type' do
+          let(:parameter_hash) do
             {
-              'name' => 'mtls param',
-              'type' => 'mtls'
+              'parameters' =>
+              [
+                {
+                  'name' => 'mtls param',
+                  'type' => 'mtls'
+                }
+              ]
             }
-          ]
-        }
-      end
+          end
 
-      context 'when validate_mtls_param is false or nil' do
-        it 'has an error when validate_mtls_param is false' do
-          create_package(parameter_hash)
-          errors = ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: false)
-          expect(errors.map(&:to_s)).to include('mtls is an invalid parameter type.')
+          it 'has no error' do
+            create_package(parameter_hash)
+            errors = ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: true)
+            expect(errors.map(&:to_s)).not_to include('mtls is an invalid parameter type.')
+          end
         end
 
-        it 'has an error by default when validate_mtls_param is nil' do
-          create_package(parameter_hash)
-          expect(@package).to have_error 'mtls is an invalid parameter type.'
-        end
-      end
+        context 'mtls_cannot_have_certain_settings' do
+          def errors_for_mtls_settings(parameter_overrides)
+            parameter_hash = {
+              'parameters' =>
+              [
+                {
+                  'name' => 'mtls param',
+                  'type' => 'mtls'
+                }.merge(parameter_overrides)
+              ]
+            }
+            create_package(parameter_hash)
+            ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: true)
+          end
 
-      context 'when validate_mtls_param is true' do
-        it 'has no error' do
-          create_package(parameter_hash)
-          errors = ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: true)
-          expect(errors.map(&:to_s)).not_to include('mtls is an invalid parameter type.')
-        end
-      end
-    end
+          it 'has no error when mtls parameter has none of default, secure or scopes set' do
+            errors = errors_for_mtls_settings({})
+            expect(errors.map(&:to_s)).not_to include('mtls parameter cannot have default, secure, or scopes settings.')
+          end
 
-    context 'mtls_cannot_have_certain_settings' do
-      def errors_for(parameter_overrides)
-        parameter_hash = {
-          'parameters' =>
-          [
-            {
-              'name' => 'mtls param',
-              'type' => 'mtls'
-            }.merge(parameter_overrides)
-          ]
-        }
-        create_package(parameter_hash)
-        ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: true)
-      end
+          it 'has an error when mtls parameter has secure set' do
+            errors = errors_for_mtls_settings('secure' => true)
+            expect(errors.map(&:to_s)).to include('mtls parameter cannot have default, secure, or scopes settings.')
+          end
 
-      context 'when validate_mtls_param is true' do
-        it 'has no error when mtls parameter has none of default, secure or scopes set' do
-          errors = errors_for({})
-          expect(errors.map(&:to_s)).not_to include('mtls parameter cannot have default, secure, or scopes settings.')
-        end
+          it 'has an error when mtls parameter has default set' do
+            errors = errors_for_mtls_settings('default' => 'mysubdomain')
+            expect(errors.map(&:to_s)).to include('mtls parameter cannot have default, secure, or scopes settings.')
+          end
 
-        it 'has an error when mtls parameter has secure set' do
-          errors = errors_for('secure' => true)
-          expect(errors.map(&:to_s)).to include('mtls parameter cannot have default, secure, or scopes settings.')
+          it 'has an error when mtls parameter has scopes set' do
+            errors = errors_for_mtls_settings('scopes' => ['header'], 'secure' => true)
+            expect(errors.map(&:to_s)).to include('mtls parameter cannot have default, secure, or scopes settings.')
+          end
         end
 
-        it 'has an error when mtls parameter has default set' do
-          errors = errors_for('default' => 'mysubdomain')
-          expect(errors.map(&:to_s)).to include('mtls parameter cannot have default, secure, or scopes settings.')
+        context 'number of mtls parameters' do
+          def mtls_parameters(count)
+            Array.new(count) { |i| { 'name' => "mtls param #{i}", 'type' => 'mtls' } }
+          end
+
+          it 'has no error when there are three or fewer mtls parameters' do
+            parameter_hash = { 'parameters' => mtls_parameters(3) }
+            create_package(parameter_hash)
+            errors = ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: true)
+            expect(errors.map(&:to_s)).not_to include("Too many parameters with type 'mtls': three permitted")
+          end
+
+          it 'has an error when there are more than three mtls parameters' do
+            parameter_hash = { 'parameters' => mtls_parameters(4) }
+            create_package(parameter_hash)
+            errors = ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: true)
+            expect(errors.map(&:to_s)).to include("Too many parameters with type 'mtls': three permitted")
+          end
         end
 
-        it 'has an error when mtls parameter has scopes set' do
-          errors = errors_for('scopes' => ['header'], 'secure' => true)
-          expect(errors.map(&:to_s)).to include('mtls parameter cannot have default, secure, or scopes settings.')
-        end
-      end
+        context 'mtls allowed_domain' do
+          def errors_for_mtls_allowed_domain(allowed_domain_overrides)
+            parameter_hash = {
+              'parameters' =>
+              [
+                {
+                  'name' => 'mtls param',
+                  'type' => 'mtls'
+                }.merge(allowed_domain_overrides)
+              ]
+            }
+            create_package(parameter_hash)
+            ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: true)
+          end
 
-      context 'when validate_mtls_param is false' do
-        it 'does not check mtls parameter settings' do
-          parameter_hash = {
-            'parameters' =>
-            [
-              {
-                'name' => 'mtls param',
-                'type' => 'mtls',
-                'secure' => true
-              }
-            ]
-          }
-          create_package(parameter_hash)
-          errors = ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: false)
-          expect(errors.map(&:to_s)).not_to include('mtls parameter cannot have default, secure, or scopes settings.')
-        end
-      end
-    end
+          let(:field) { 'parameters[name="mtls param"].allowed_domain' }
 
-    context 'number of mtls parameters' do
-      def mtls_parameters(count)
-        Array.new(count) { |i| { 'name' => "mtls param #{i}", 'type' => 'mtls' } }
-      end
+          it 'has an error when allowed_domain is missing' do
+            errors = errors_for_mtls_allowed_domain({})
+            expect(errors.map(&:to_s)).to include("#{field} cannot be empty.")
+          end
 
-      context 'when validate_mtls_param is true' do
-        it 'has no error when there are three or fewer mtls parameters' do
-          parameter_hash = { 'parameters' => mtls_parameters(3) }
-          create_package(parameter_hash)
-          errors = ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: true)
-          expect(errors.map(&:to_s)).not_to include("Too many parameters with type 'mtls': three permitted")
-        end
+          it 'has an error when allowed_domain is empty' do
+            errors = errors_for_mtls_allowed_domain('allowed_domain' => '')
+            expect(errors.map(&:to_s)).to include("#{field} cannot be empty.")
+          end
 
-        it 'has an error when there are more than three mtls parameters' do
-          parameter_hash = { 'parameters' => mtls_parameters(4) }
-          create_package(parameter_hash)
-          errors = ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: true)
-          expect(errors.map(&:to_s)).to include("Too many parameters with type 'mtls': three permitted")
-        end
-      end
+          it 'has an error when allowed_domain is not a string' do
+            errors = errors_for_mtls_allowed_domain('allowed_domain' => 123)
+            expect(errors.map(&:to_s)).to include(%(#{field} must be a string, got "123".))
+          end
 
-      context 'when validate_mtls_param is false' do
-        it 'does not check the count of mtls parameters' do
-          parameter_hash = { 'parameters' => mtls_parameters(4) }
-          create_package(parameter_hash)
-          errors = ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: false)
-          expect(errors.map(&:to_s)).not_to include("Too many parameters with type 'mtls': three permitted")
-        end
-      end
-    end
+          it 'has an error when allowed_domain includes a scheme' do
+            errors = errors_for_mtls_allowed_domain('allowed_domain' => 'https://example.com')
+            expect(errors.map(&:to_s)).to include(%(#{field} must not include a protocol or scheme.))
+          end
 
-    context 'mtls allowed_domain' do
-      def errors_for(allowed_domain_overrides)
-        parameter_hash = {
-          'parameters' =>
-          [
-            {
-              'name' => 'mtls param',
-              'type' => 'mtls'
-            }.merge(allowed_domain_overrides)
-          ]
-        }
-        create_package(parameter_hash)
-        ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: true)
-      end
+          it 'has an error when allowed_domain exceeds 253 characters' do
+            long_domain = "#{'a' * 250}.com"
+            errors = errors_for_mtls_allowed_domain('allowed_domain' => long_domain)
+            expect(errors.map(&:to_s)).to include(%(#{field} must not exceed 253 characters.))
+          end
 
-      let(:field) { 'parameters[name="mtls param"].allowed_domain' }
+          it 'has an error when a subdomain label exceeds 63 characters' do
+            long_label = 'a' * 64
+            errors = errors_for_mtls_allowed_domain('allowed_domain' => "#{long_label}.com")
+            expect(errors.map(&:to_s)).to include(%(#{field} must be a valid domain name.))
+          end
 
-      context 'when validate_mtls_param is true' do
-        it 'has an error when allowed_domain is missing' do
-          errors = errors_for({})
-          expect(errors.map(&:to_s)).to include("#{field} cannot be empty.")
-        end
+          it 'has an error when the wildcard is not the first two characters' do
+            errors = errors_for_mtls_allowed_domain('allowed_domain' => 'my-*.zendesk.com')
+            expect(errors.map(&:to_s))
+              .to include(%(#{field} can only use a wildcard as the first two characters, e.g. *.example.com.))
+          end
 
-        it 'has an error when allowed_domain is empty' do
-          errors = errors_for('allowed_domain' => '')
-          expect(errors.map(&:to_s)).to include("#{field} cannot be empty.")
-        end
+          it 'has an error when allowed_domain is not a valid domain name' do
+            errors = errors_for_mtls_allowed_domain('allowed_domain' => 'not_a_domain')
+            expect(errors.map(&:to_s)).to include(%(#{field} must be a valid domain name.))
+          end
 
-        it 'has an error when allowed_domain is not a string' do
-          errors = errors_for('allowed_domain' => 123)
-          expect(errors.map(&:to_s)).to include(%(#{field} must be a string, got "123".))
-        end
+          it 'has no error for a valid bare domain' do
+            errors = errors_for_mtls_allowed_domain('allowed_domain' => 'my-domain.com')
+            expect(errors.map(&:to_s)).to be_empty
+          end
 
-        it 'has an error when allowed_domain includes a scheme' do
-          errors = errors_for('allowed_domain' => 'https://example.com')
-          expect(errors.map(&:to_s)).to include(%(#{field} must not include a protocol or scheme.))
-        end
-
-        it 'has an error when allowed_domain exceeds 253 characters' do
-          long_domain = "#{'a' * 250}.com"
-          errors = errors_for('allowed_domain' => long_domain)
-          expect(errors.map(&:to_s)).to include(%(#{field} must not exceed 253 characters.))
-        end
-
-        it 'has an error when a subdomain label exceeds 63 characters' do
-          long_label = 'a' * 64
-          errors = errors_for('allowed_domain' => "#{long_label}.com")
-          expect(errors.map(&:to_s)).to include(%(#{field} must be a valid domain name.))
-        end
-
-        it 'has an error when the wildcard is not the first two characters' do
-          errors = errors_for('allowed_domain' => 'my-*.zendesk.com')
-          expect(errors.map(&:to_s))
-            .to include(%(#{field} can only use a wildcard as the first two characters, e.g. *.example.com.))
-        end
-
-        it 'has an error when allowed_domain is not a valid domain name' do
-          errors = errors_for('allowed_domain' => 'not_a_domain')
-          expect(errors.map(&:to_s)).to include(%(#{field} must be a valid domain name.))
-        end
-
-        it 'has no error for a valid bare domain' do
-          errors = errors_for('allowed_domain' => 'my-domain.com')
-          expect(errors.map(&:to_s)).to be_empty
-        end
-
-        it 'has no error for a valid wildcard subdomain' do
-          errors = errors_for('allowed_domain' => '*.my-domain.com')
-          expect(errors.map(&:to_s)).to be_empty
+          it 'has no error for a valid wildcard subdomain' do
+            errors = errors_for_mtls_allowed_domain('allowed_domain' => '*.my-domain.com')
+            expect(errors.map(&:to_s)).to be_empty
+          end
         end
       end
 
       context 'when validate_mtls_param is false' do
-        it 'does not check allowed_domain' do
+        it 'fails with an invalid parameter type error instead of checking mtls parameter settings' do
           parameter_hash = {
             'parameters' =>
             [
@@ -862,7 +818,7 @@ describe ZendeskAppsSupport::Validations::Manifest do
           }
           create_package(parameter_hash)
           errors = ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: false)
-          expect(errors.map(&:to_s)).not_to include("#{field} cannot be empty.")
+          expect(errors.map(&:to_s)).to include('mtls is an invalid parameter type.')
         end
       end
     end

--- a/spec/validations/manifest_spec.rb
+++ b/spec/validations/manifest_spec.rb
@@ -777,6 +777,96 @@ describe ZendeskAppsSupport::Validations::Manifest do
       end
     end
 
+    context 'mtls allowed_domain' do
+      def errors_for(allowed_domain_overrides)
+        parameter_hash = {
+          'parameters' =>
+          [
+            {
+              'name' => 'mtls param',
+              'type' => 'mtls'
+            }.merge(allowed_domain_overrides)
+          ]
+        }
+        create_package(parameter_hash)
+        ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: true)
+      end
+
+      let(:field) { 'parameters[name="mtls param"].allowed_domain' }
+
+      context 'when validate_mtls_param is true' do
+        it 'has an error when allowed_domain is missing' do
+          errors = errors_for({})
+          expect(errors.map(&:to_s)).to include("#{field} cannot be empty.")
+        end
+
+        it 'has an error when allowed_domain is empty' do
+          errors = errors_for('allowed_domain' => '')
+          expect(errors.map(&:to_s)).to include("#{field} cannot be empty.")
+        end
+
+        it 'has an error when allowed_domain is not a string' do
+          errors = errors_for('allowed_domain' => 123)
+          expect(errors.map(&:to_s)).to include(%(#{field} must be a string, got "123".))
+        end
+
+        it 'has an error when allowed_domain includes a scheme' do
+          errors = errors_for('allowed_domain' => 'https://example.com')
+          expect(errors.map(&:to_s)).to include(%(#{field} must not include a protocol or scheme.))
+        end
+
+        it 'has an error when allowed_domain exceeds 253 characters' do
+          long_domain = "#{'a' * 250}.com"
+          errors = errors_for('allowed_domain' => long_domain)
+          expect(errors.map(&:to_s)).to include(%(#{field} must not exceed 253 characters.))
+        end
+
+        it 'has an error when a subdomain label exceeds 63 characters' do
+          long_label = 'a' * 64
+          errors = errors_for('allowed_domain' => "#{long_label}.com")
+          expect(errors.map(&:to_s)).to include(%(#{field} must be a valid domain name.))
+        end
+
+        it 'has an error when the wildcard is not the first two characters' do
+          errors = errors_for('allowed_domain' => 'my-*.zendesk.com')
+          expect(errors.map(&:to_s))
+            .to include(%(#{field} can only use a wildcard as the first two characters, e.g. *.example.com.))
+        end
+
+        it 'has an error when allowed_domain is not a valid domain name' do
+          errors = errors_for('allowed_domain' => 'not_a_domain')
+          expect(errors.map(&:to_s)).to include(%(#{field} must be a valid domain name.))
+        end
+
+        it 'has no error for a valid bare domain' do
+          errors = errors_for('allowed_domain' => 'my-domain.com')
+          expect(errors.map(&:to_s)).to be_empty
+        end
+
+        it 'has no error for a valid wildcard subdomain' do
+          errors = errors_for('allowed_domain' => '*.my-domain.com')
+          expect(errors.map(&:to_s)).to be_empty
+        end
+      end
+
+      context 'when validate_mtls_param is false' do
+        it 'does not check allowed_domain' do
+          parameter_hash = {
+            'parameters' =>
+            [
+              {
+                'name' => 'mtls param',
+                'type' => 'mtls'
+              }
+            ]
+          }
+          create_package(parameter_hash)
+          errors = ZendeskAppsSupport::Validations::Manifest.call(@package, validate_mtls_param: false)
+          expect(errors.map(&:to_s)).not_to include("#{field} cannot be empty.")
+        end
+      end
+    end
+
     it 'should have only one oauth type for parameter' do
       parameter_hash = {
         'parameters' =>


### PR DESCRIPTION
💐

/cc @zendesk/wattle

### Description
Added following validations for `mtls` parameter type in app's manifest file.

**Validations**:
- `default`, `secure` or `scopes` cannot be set when parameter type is `mtls` and should fail validation.
- Limit of 3 mtls parameters per app.
- Validations are behind `validate_mtls_param` option supported by the `validate` method of the gem
- When the validation option is `true`:
    - mtls parameter is validated and exposed by ZAS.
- When the the validation option is `false`:
    - Package validation should fail if a `mtls` parameter is provided in the manifest file.
- For `allowed_domain` property:
  - presence -> must be provided 
  - type -> has to be a string
  - no protocol or scheme in the allowed_domain value e.g, `https://*.zendesk.com`
  - allowed_domain value can't exceed 253 characters
  - A subdomain in the value can't exceed 63 characters
  - wildcard -> allowed only at the start (e.g. `*.example.com`), not-allowed anywhere else (e.g. `my-*.zendesk.com`)
  - valid values - `example.com`, `*.example.com`, `a.b.example.com`
  - invalid values - `https://example.com`, `https://*.zendesk.com`, 123
  
### References

JIRA: https://zendesk.atlassian.net/browse/APPS-8403

#### Before merging this PR
- [x] Fill out the Risks section
- [x] Think about performance and security issues

### Risks
* [RUNTIME] Can this change affect apps rendering for a user? - No
* [HIGH | medium | low] What features does this touch?
